### PR TITLE
Add predict_survival_function and predict_cumulative_hazard_function to CoxnetSurvivalAnalysis

### DIFF
--- a/tests/test_coxnet.py
+++ b/tests/test_coxnet.py
@@ -425,6 +425,36 @@ class TestCoxnetSurvivalAnalysis(object):
             coxnet.predict(x.iloc[[122, 10, 22, 200], :], alpha=a) for a in [0.75, 0.25, 0.2, 0.15, 0.1, 0.075]])
         assert_array_almost_equal(pred, expected_pred)
 
+    def test_example_2_predict_func(self):
+        x, coxnet = self._fit_example(l1_ratio=0.9, n_alphas=11,
+                                      alpha_min_ratio=0.001,
+                                      fit_baseline_model=True)
+
+        xtest = x.iloc[[122, 10, 22, 200], :]
+        for a in [None] + list(coxnet.alphas_):
+            chf = coxnet.predict_cumulative_hazard_function(xtest, alpha=a)
+            assert len(chf) == 4
+
+            sf = coxnet.predict_survival_function(xtest, alpha=a)
+            assert len(sf) == 4
+
+    def test_predict_func_disabled(self):
+        x, coxnet = self._fit_example(l1_ratio=0.9, n_alphas=11,
+                                      alpha_min_ratio=0.001,
+                                      fit_baseline_model=False)
+        with pytest.raises(ValueError,
+                           match='`fit` must be called with the fit_baseline_model option set to True.'):
+            coxnet.predict_cumulative_hazard_function(x)
+
+    def test_predict_func_no_such_alpha(self):
+        x, coxnet = self._fit_example(l1_ratio=0.9, n_alphas=11,
+                                      alpha_min_ratio=0.001,
+                                      fit_baseline_model=True)
+        with pytest.raises(ValueError,
+                           match=r'alpha must be one value of alphas_: \[.+'):
+            for a in 1. + numpy.random.randn(100):
+                coxnet.predict_cumulative_hazard_function(x, alpha=a)
+
     def test_all_zero_coefs(self):
         alphas = numpy.array([256, 128, 96, 64, 48])
 

--- a/tests/test_coxph.py
+++ b/tests/test_coxph.py
@@ -137,7 +137,7 @@ class TestCoxPH(object):
         expected_x = numpy.array(
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 30,
              31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52])
-        assert_array_almost_equal(cph.cum_baseline_hazard_.x, expected_x)
+        assert_array_almost_equal(cph._baseline_model.cum_baseline_hazard_.x, expected_x)
 
         expected_y = numpy.array(
             [0.00678640369024364, 0.0135929334270716, 0.0204043079886091, 0.0272294776707967, 0.0340761479284598,
@@ -151,7 +151,7 @@ class TestCoxPH(object):
              0.72608698374096, 0.744888154417096, 0.763829951751727, 0.802133842428817, 0.811813515937835,
              0.831261170527727, 0.880363253205648, 0.910240767958261, 0.950727380604515])
 
-        actual_y = [cph.cum_baseline_hazard_(v) for v in expected_x]
+        actual_y = [cph._baseline_model.cum_baseline_hazard_(v) for v in expected_x]
         # check that values increase
         assert (numpy.diff(actual_y) > 0).all()
         assert_array_almost_equal(actual_y, expected_y)


### PR DESCRIPTION
Estimating the baseline cumulative hazard function requires access to estimated coefficients and survival times from the training data. While `predict` allows specifying arbitrary `alpha` values by interpolating coefficients, we can't do this for `predict_survival_function` and `predict_cumulative_hazard_function` without keeping a copy of the training data. Therefore, both functions only accept `alpha` values that have been used during fitting and are stored in `alphas_`. To avoid increasing training time, estimating the baseline cumulative hazard function is disabled by default, set `fit_baseline_model = True` if you need it.

Fixes #46