### PR TITLE
Remove version on osqp, set min version on pandas

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,7 @@ cvxpy >=1.0
 cython >=0.29
 numexpr
 numpy
-osqp !=0.6.0,!=0.6.1
-pandas >=0.21,<0.26
+osqp >0.6.0
+pandas >=0.21
 scipy >=1.0,!=1.3.0
 scikit-learn >=0.21.0,<0.22


### PR DESCRIPTION
## Motivation

I am packaging this python package for Nix. See https://github.com/NixOS/nixpkgs/pull/82410

## Notes

Using those modifications I have successfully built and tested the package using Nix.

Althought it is clear to me that if those restrictions where placed here, it was for a reason.
Please let me know if something was missed.