### PR TITLE
Fix score function if predictions are on time scale

### DIFF
--- a/sksurv/base.py
+++ b/sksurv/base.py
@@ -35,5 +35,9 @@ class SurvivalAnalysisMixin(object):
         from .metrics import concordance_index_censored
         name_event, name_time = y.dtype.names
 
-        result = concordance_index_censored(y[name_event], y[name_time], self.predict(X))
+        risk_score = self.predict(X)
+        if not getattr(self, "_predict_risk_score", True):
+            risk_score *= -1  # convert prediction on time scale to risk scale
+
+        result = concordance_index_censored(y[name_event], y[name_time], risk_score)
         return result[0]

--- a/sksurv/ensemble/boosting.py
+++ b/sksurv/ensemble/boosting.py
@@ -30,7 +30,7 @@ from scipy.sparse import csc_matrix, csr_matrix, issparse
 from ..base import SurvivalAnalysisMixin
 from ..util import check_arrays_survival
 from .survival_loss import LOSS_FUNCTIONS, CensoredSquaredLoss, \
-    IPCWLeastSquaresError
+    CoxPH, IPCWLeastSquaresError
 
 
 __all__ = ['ComponentwiseGradientBoostingSurvivalAnalysis', 'GradientBoostingSurvivalAnalysis']
@@ -166,6 +166,10 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         self.dropout_rate = dropout_rate
         self.random_state = random_state
         self.verbose = verbose
+
+    @property
+    def _predict_risk_score(self):
+        return isinstance(self.loss_, CoxPH)
 
     def _check_params(self):
         """Check validity of parameters and raise ValueError if not valid. """
@@ -568,6 +572,10 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
                          verbose=verbose,
                          ccp_alpha=ccp_alpha)
         self.dropout_rate = dropout_rate
+
+    @property
+    def _predict_risk_score(self):
+        return isinstance(self.loss_, CoxPH)
 
     def _check_params(self):
         """Check validity of parameters and raise ValueError if not valid. """

--- a/tests/test_boosting.py
+++ b/tests/test_boosting.py
@@ -219,6 +219,9 @@ class TestGradientBoosting(object):
         rmse_uncensored = numpy.sqrt(mean_squared_error(time_true[event_true], time_predicted[event_true]))
         assert round(abs(rmse_uncensored - 392.97741487479743), 7) == 0
 
+        cindex = model.score(whas500_data.x, whas500_data.y)
+        assert round(abs(cindex - 0.8979161399), 7) == 0
+
     @staticmethod
     def test_squared_loss(make_whas500):
         whas500_data = make_whas500(with_std=False, to_numeric=True)
@@ -235,6 +238,9 @@ class TestGradientBoosting(object):
 
         rmse_uncensored = numpy.sqrt(mean_squared_error(time_true[event_true], time_predicted[event_true]))
         assert round(abs(rmse_uncensored - 383.10639243317951), 7) == 0
+
+        cindex = model.score(whas500_data.x, whas500_data.y)
+        assert round(abs(cindex - 0.9021810004), 7) == 0
 
     @staticmethod
     def test_ipcw_loss_staged_predict(make_whas500):
@@ -459,6 +465,9 @@ class TestComponentwiseGradientBoosting(object):
         rmse_uncensored = numpy.sqrt(mean_squared_error(time_true[event_true], time_predicted[event_true]))
         assert round(abs(rmse_uncensored - 542.884585289), 7) == 0
 
+        cindex = model.score(whas500_data.x, whas500_data.y)
+        assert round(abs(cindex - 0.7773356931), 7) == 0
+
     @staticmethod
     def test_squared_loss(make_whas500):
         whas500_data = make_whas500(with_std=False, to_numeric=True)
@@ -475,6 +484,9 @@ class TestComponentwiseGradientBoosting(object):
 
         rmse_uncensored = numpy.sqrt(mean_squared_error(time_true[event_true], time_predicted[event_true]))
         assert round(abs(rmse_uncensored - 542.83358120153525), 7) == 0
+
+        cindex = model.score(whas500_data.x, whas500_data.y)
+        assert round(abs(cindex - 0.7777082862), 7) == 0
 
 
 @pytest.fixture(params=[GradientBoostingSurvivalAnalysis, ComponentwiseGradientBoostingSurvivalAnalysis])


### PR DESCRIPTION
The `score` function returns the wrong concordance index for models whose predictions are on time scale. Check if estimator has a `_predict_risk_score` attribute that returns False, in which case the sign of predictions is flipped.
