### PR TITLE
Fix occasional error with nbval

### DIFF
--- a/doc/user_guide/survival-svm.ipynb
+++ b/doc/user_guide/survival-svm.ipynb
@@ -154,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimator = FastSurvivalSVM(max_iter=1000, tol=1e-6, random_state=0)"
+    "estimator = FastSurvivalSVM(max_iter=1000, tol=1e-5, random_state=0)"
    ]
   },
   {
@@ -312,7 +312,7 @@
      "data": {
       "text/plain": [
        "FastSurvivalSVM(alpha=0.00390625, max_iter=1000, optimizer='avltree',\n",
-       "                random_state=0, tol=1e-06)"
+       "                random_state=0, tol=1e-05)"
       ]
      },
      "execution_count": 12,
@@ -403,7 +403,7 @@
     }
    ],
    "source": [
-    "ref_estimator = FastSurvivalSVM(rank_ratio=0.0, max_iter=1000, tol=1e-6, random_state=0)\n",
+    "ref_estimator = FastSurvivalSVM(rank_ratio=0.0, max_iter=1000, tol=1e-5, random_state=0)\n",
     "ref_estimator.fit(x, y_log_t)\n",
     "\n",
     "cindex = concordance_index_censored(\n",


### PR DESCRIPTION
On some CI runs, a convergence warning is raised, which
nbval complatins about simply with:
`Unexpected output fields from running code: {'stderr'}`

Reduce the tolerance to avoid convergence warning.
