### PR TITLE
Solve #198. Columns dropped in `encode_categorical` with `allow_drop=False`

### DIFF
--- a/sksurv/column.py
+++ b/sksurv/column.py
@@ -91,7 +91,7 @@ def _encode_categorical_series(series, allow_drop=True):
 
     if not allow_drop and enc.shape[1] == 1:
         return series
-    
+
     names = []
     for key in range(1, enc.shape[1]):
         names.append("{}={}".format(series.name, levels[key]))

--- a/sksurv/column.py
+++ b/sksurv/column.py
@@ -89,6 +89,9 @@ def _encode_categorical_series(series, allow_drop=True):
     if enc is None:
         return pandas.Series(index=series.index, name=series.name, dtype=series.dtype)
 
+    if not allow_drop and enc.shape[1] == 1:
+        return series
+    
     names = []
     for key in range(1, enc.shape[1]):
         names.append("{}={}".format(series.name, levels[key]))

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -329,6 +329,22 @@ class TestEncodeCategorical(object):
         tm.assert_frame_equal(actual_df.isnull(), expected_df.isnull())
         tm.assert_frame_equal(actual_df.dropna(), expected_df.dropna(), check_exact=True)
 
+    @staticmethod
+    def test_retain_only_one_level():
+        b = numpy.r_[numpy.repeat(["yes"], 10)]
+
+        all_missing = numpy.repeat([None], len(b))
+
+        df = pandas.DataFrame({"categorical_col_with_only_one_level": b})
+
+        expected_df = df.copy(deep=True)
+
+        actual_df = column.encode_categorical(df, allow_drop=False)
+
+        assert actual_df.shape == expected_df.shape
+        tm.assert_frame_equal(actual_df.isnull(), expected_df.isnull())
+        tm.assert_frame_equal(actual_df.dropna(), expected_df.dropna(), check_exact=True)
+
 
 def test_categorical_series_to_numeric():
     input_series = pandas.Series(["a", "a", "b", "b", "b", "c"], name="Thr33",

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -333,8 +333,6 @@ class TestEncodeCategorical(object):
     def test_retain_only_one_level():
         b = numpy.r_[numpy.repeat(["yes"], 10)]
 
-        all_missing = numpy.repeat([None], len(b))
-
         df = pandas.DataFrame({"categorical_col_with_only_one_level": b})
 
         expected_df = df.copy(deep=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #198
- [x] py.test passes
- [x] tests are included
- [x] code is well formatted
- [ ] documentation renders correctly

**What does this implement/fix? Explain your changes**
This pull request closes #198. Columns are no longer dropped when running `encode_categorical` with `allow_drop=False`.