### PR TITLE
Faster speed for compare_survival

### DIFF
--- a/sksurv/compare.py
+++ b/sksurv/compare.py
@@ -75,7 +75,9 @@ def compare_survival(y, group_indicator, return_stats=False):
     observed = numpy.zeros(n_groups, dtype=numpy.int_)
     expected = numpy.zeros(n_groups, dtype=numpy.float_)
     covar = numpy.zeros((n_groups, n_groups), dtype=numpy.float_)
-    group_eye = numpy.eye(n_groups, dtype=bool)
+
+    covar_indices = numpy.diag_indices(n_groups)
+
     k = 0
     while k < n_samples:
         ti = time[k]
@@ -94,8 +96,8 @@ def compare_survival(y, group_indicator, return_stats=False):
             if total_at_risk > 1:
                 multiplier = total_events * (total_at_risk - total_events) / (total_at_risk * (total_at_risk - 1))
                 temp = at_risk * multiplier
-                covar[group_eye] += temp
-                covar -= (temp[:, None] * at_risk[None, :] / total_at_risk)
+                covar[covar_indices] += temp
+                covar -= numpy.outer(temp, at_risk) / total_at_risk
 
     df = n_groups - 1
     zz = observed[:df] - expected[:df]

--- a/sksurv/compare.py
+++ b/sksurv/compare.py
@@ -75,6 +75,7 @@ def compare_survival(y, group_indicator, return_stats=False):
     observed = numpy.zeros(n_groups, dtype=numpy.int_)
     expected = numpy.zeros(n_groups, dtype=numpy.float_)
     covar = numpy.zeros((n_groups, n_groups), dtype=numpy.float_)
+    group_eye = numpy.eye(n_groups, dtype=bool)
     k = 0
     while k < n_samples:
         ti = time[k]
@@ -92,11 +93,9 @@ def compare_survival(y, group_indicator, return_stats=False):
             expected += at_risk * (total_events / total_at_risk)
             if total_at_risk > 1:
                 multiplier = total_events * (total_at_risk - total_events) / (total_at_risk * (total_at_risk - 1))
-                for g1 in range(n_groups):
-                    temp = at_risk[g1] * multiplier
-                    covar[g1, g1] += temp
-                    for g2 in range(n_groups):
-                        covar[g1, g2] -= temp * at_risk[g2] / total_at_risk
+                temp = at_risk * multiplier
+                covar[group_eye] += temp
+                covar -= (temp[:, None] * at_risk[None, :] / total_at_risk)
 
     df = n_groups - 1
     zz = observed[:df] - expected[:df]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #214 
- [x] py.test passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
* The change can improve the speed for function [sksurv.compare.compare_survival](https://github.com/sebp/scikit-survival/blob/master/sksurv/compare.py)
* Use more ```numpy``` native syntax/ operation to accelerate the python iteration on a huge cartetian product
* The actual scale of improvement depends on how large the n_groups is
* Per testing, the function will return same ```chisq```, ```pvalue```, ```covar``` matrix, ```table```