### PR TITLE
Added backward support for gcc-c++

### DIFF
--- a/sksurv/linear_model/src/coxnet/coxnet.h
+++ b/sksurv/linear_model/src/coxnet/coxnet.h
@@ -136,7 +136,7 @@ Coxnet<T, S, U>::update ()
 
         while (k < n_samples && ti == time[k]) {
             /* abort if values are too large */
-            if (!isfinite(exp_xw[k])) {
+            if (!std::isfinite(exp_xw[k])) {
                 m_params.error_type = WEIGHT_TOO_LARGE;
             }
             v += exp_xw[k] * norm_factor;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**

- [x] py.test passes
- [x] code is well formatted
- [x] further testing on C++ compilers >=10

**What does this implement/fix? Explain your changes**

Ability to install the package against C/C++ compiler versions <10. Running into following issue during installation of the package
> Error: 'isfinite' was not declared in this scope!

The fix is tested against version gcc-c++ version 4.8 that gets shipped with RHEL 7. 

<!-- Further testing is required on C/C++ compiler versions >=10 to check the backward compatibility for std::isfinite variable. Latest Update:- Looks like the builds are success. So marking this test as done -->