### PR TITLE
ENH: Add return_array argument to predict_*_function

### DIFF
--- a/sksurv/base.py
+++ b/sksurv/base.py
@@ -10,9 +10,65 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy
 
 
 class SurvivalAnalysisMixin:
+    def _predict_function(self, func_name, baseline_model, prediction, return_array):
+        fns = getattr(baseline_model, func_name)(prediction)
+
+        if not return_array:
+            return fns
+
+        times = baseline_model.unique_times_
+        arr = numpy.empty((prediction.shape[0], times.shape[0]), dtype=float)
+        for i, fn in enumerate(fns):
+            arr[i, :] = fn(times)
+        return arr
+
+    def _predict_survival_function(self, baseline_model, prediction, return_array):
+        """Return survival functions.
+
+        Parameters
+        ----------
+        baseline_model : sksurv.linear_model.coxph.BreslowEstimator
+            Estimator of baseline survival function.
+
+        prediction : array-like, shape=(n_samples,)
+            Predicted risk scores.
+
+        return_array : bool
+            If True, return a float array of the survival function
+            evaluated at the unique event times, otherwise return
+            an array of :class:`sksurv.functions.StepFunction` instances.
+
+        Returns
+        -------
+        survival : ndarray
+        """
+        return self._predict_function("get_survival_function", baseline_model, prediction, return_array)
+
+    def _predict_cumulative_hazard_function(self, baseline_model, prediction, return_array):
+        """Return cumulative hazard functions.
+
+        Parameters
+        ----------
+        baseline_model : sksurv.linear_model.coxph.BreslowEstimator
+            Estimator of baseline cumulative hazard function.
+
+        prediction : array-like, shape=(n_samples,)
+            Predicted risk scores.
+
+        return_array : bool
+            If True, return a float array of the cumulative hazard function
+            evaluated at the unique event times, otherwise return
+            an array of :class:`sksurv.functions.StepFunction` instances.
+
+        Returns
+        -------
+        cum_hazard : ndarray
+        """
+        return self._predict_function("get_cumulative_hazard_function", baseline_model, prediction, return_array)
 
     def score(self, X, y):
         """Returns the concordance index of the prediction.

--- a/sksurv/ensemble/boosting.py
+++ b/sksurv/ensemble/boosting.py
@@ -155,6 +155,9 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         Names of features seen during ``fit``. Defined only when `X`
         has feature names that are all strings.
 
+    event_times_ : array of shape = (n_event_times,)
+        Unique time points where events occurred.
+
     References
     ----------
     .. [1] Hothorn, T., Bühlmann, P., Dudoit, S., Molinaro, A., van der Laan, M. J.,
@@ -358,7 +361,7 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
             raise ValueError("`fit` must be called with the loss option set to 'coxph'.")
         return self._baseline_model
 
-    def predict_cumulative_hazard_function(self, X):
+    def predict_cumulative_hazard_function(self, X, return_array=False):
         """Predict cumulative hazard function.
 
         Only available if :meth:`fit` has been called with `loss = "coxph"`.
@@ -379,10 +382,17 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
+        return_array : boolean, default: False
+            If set, return an array with the cumulative hazard rate
+            for each `self.event_times_`, otherwise an array of
+            :class:`sksurv.functions.StepFunction`.
+
         Returns
         -------
-        cum_hazard : ndarray of :class:`sksurv.functions.StepFunction`, shape = (n_samples,)
-            Predicted cumulative hazard functions.
+        cum_hazard : ndarray
+            If `return_array` is set, an array with the cumulative hazard rate
+            for each `self.event_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
 
         Examples
         --------
@@ -411,9 +421,11 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         >>> plt.ylim(0, 1)
         >>> plt.show()
         """
-        return self._get_baseline_model().get_cumulative_hazard_function(self.predict(X))
+        return self._predict_cumulative_hazard_function(
+            self._get_baseline_model(), self.predict(X), return_array
+        )
 
-    def predict_survival_function(self, X):
+    def predict_survival_function(self, X, return_array=False):
         """Predict survival function.
 
         Only available if :meth:`fit` has been called with `loss = "coxph"`.
@@ -434,10 +446,18 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
+        return_array : boolean, default: False
+            If set, return an array with the probability
+            of survival for each `self.event_times_`,
+            otherwise an array of :class:`sksurv.functions.StepFunction`.
+
         Returns
         -------
-        survival : ndarray of :class:`sksurv.functions.StepFunction`, shape = (n_samples,)
-            Predicted survival functions.
+        survival : ndarray
+            If `return_array` is set, an array with the probability of
+            survival for each `self.event_times_`, otherwise an array of
+            length `n_samples` of :class:`sksurv.functions.StepFunction`
+            instances will be returned.
 
         Examples
         --------
@@ -466,7 +486,9 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
         >>> plt.ylim(0, 1)
         >>> plt.show()
         """
-        return self._get_baseline_model().get_survival_function(self.predict(X))
+        return self._predict_survival_function(
+            self._get_baseline_model(), self.predict(X), return_array
+        )
 
     @property
     def coef_(self):
@@ -476,6 +498,10 @@ class ComponentwiseGradientBoostingSurvivalAnalysis(BaseEnsemble, SurvivalAnalys
             coef[estimator.component] += self.learning_rate * estimator.coef_
 
         return coef
+
+    @property
+    def event_times_(self):
+        return self._get_baseline_model().unique_times_
 
     @property
     def feature_importances_(self):
@@ -654,6 +680,9 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during ``fit``. Defined only when `X`
         has feature names that are all strings.
+
+    event_times_ : array of shape = (n_event_times,)
+        Unique time points where events occurred.
 
     References
     ----------
@@ -1102,7 +1131,7 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
             raise ValueError("`fit` must be called with the loss option set to 'coxph'.")
         return self._baseline_model
 
-    def predict_cumulative_hazard_function(self, X):
+    def predict_cumulative_hazard_function(self, X, return_array=False):
         """Predict cumulative hazard function.
 
         Only available if :meth:`fit` has been called with `loss = "coxph"`.
@@ -1123,10 +1152,17 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
+        return_array : boolean, default: False
+            If set, return an array with the cumulative hazard rate
+            for each `self.event_times_`, otherwise an array of
+            :class:`sksurv.functions.StepFunction`.
+
         Returns
         -------
-        cum_hazard : ndarray of :class:`sksurv.functions.StepFunction`, shape = (n_samples,)
-            Predicted cumulative hazard functions.
+        cum_hazard : ndarray
+            If `return_array` is set, an array with the cumulative hazard rate
+            for each `self.event_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
 
         Examples
         --------
@@ -1155,9 +1191,11 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         >>> plt.ylim(0, 1)
         >>> plt.show()
         """
-        return self._get_baseline_model().get_cumulative_hazard_function(self.predict(X))
+        return self._predict_cumulative_hazard_function(
+            self._get_baseline_model(), self.predict(X), return_array
+        )
 
-    def predict_survival_function(self, X):
+    def predict_survival_function(self, X, return_array=False):
         """Predict survival function.
 
         Only available if :meth:`fit` has been called with `loss = "coxph"`.
@@ -1178,10 +1216,18 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
+        return_array : boolean, default: False
+            If set, return an array with the probability
+            of survival for each `self.event_times_`,
+            otherwise an array of :class:`sksurv.functions.StepFunction`.
+
         Returns
         -------
-        survival : ndarray of :class:`sksurv.functions.StepFunction`, shape = (n_samples,)
-            Predicted survival functions.
+        survival : ndarray
+            If `return_array` is set, an array with the probability of
+            survival for each `self.event_times_`, otherwise an array of
+            length `n_samples` of :class:`sksurv.functions.StepFunction`
+            instances will be returned.
 
         Examples
         --------
@@ -1210,4 +1256,10 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         >>> plt.ylim(0, 1)
         >>> plt.show()
         """
-        return self._get_baseline_model().get_survival_function(self.predict(X))
+        return self._predict_survival_function(
+            self._get_baseline_model(), self.predict(X), return_array
+        )
+
+    @property
+    def event_times_(self):
+        return self._get_baseline_model().unique_times_

--- a/sksurv/ensemble/forest.py
+++ b/sksurv/ensemble/forest.py
@@ -480,7 +480,7 @@ class RandomSurvivalForest(_BaseSurvivalForest):
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
-        return_array : boolean
+        return_array : boolean, default: False
             If set, return an array with the cumulative hazard rate
             for each `self.event_times_`, otherwise an array of
             :class:`sksurv.functions.StepFunction`.
@@ -489,8 +489,8 @@ class RandomSurvivalForest(_BaseSurvivalForest):
         -------
         cum_hazard : ndarray
             If `return_array` is set, an array with the cumulative hazard rate
-            for each `self.event_times_`, otherwise an array of
-            :class:`sksurv.functions.StepFunction` will be returned.
+            for each `self.event_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
 
         Examples
         --------
@@ -772,7 +772,7 @@ class ExtraSurvivalTrees(_BaseSurvivalForest):
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
-        return_array : boolean
+        return_array : boolean, default: False
             If set, return an array with the cumulative hazard rate
             for each `self.event_times_`, otherwise an array of
             :class:`sksurv.functions.StepFunction`.
@@ -781,8 +781,8 @@ class ExtraSurvivalTrees(_BaseSurvivalForest):
         -------
         cum_hazard : ndarray
             If `return_array` is set, an array with the cumulative hazard rate
-            for each `self.event_times_`, otherwise an array of
-            :class:`sksurv.functions.StepFunction` will be returned.
+            for each `self.event_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
 
         Examples
         --------
@@ -830,7 +830,7 @@ class ExtraSurvivalTrees(_BaseSurvivalForest):
         X : array-like, shape = (n_samples, n_features)
             Data matrix.
 
-        return_array : boolean
+        return_array : boolean, default: False
             If set, return an array with the probability
             of survival for each `self.event_times_`,
             otherwise an array of :class:`sksurv.functions.StepFunction`.
@@ -838,10 +838,10 @@ class ExtraSurvivalTrees(_BaseSurvivalForest):
         Returns
         -------
         survival : ndarray
-            If `return_array` is set, an array with the probability
-            of survival for each `self.event_times_`,
-            otherwise an array of :class:`sksurv.functions.StepFunction`
-            will be returned.
+            If `return_array` is set, an array with the probability of
+            survival for each `self.event_times_`, otherwise an array of
+            length `n_samples` of :class:`sksurv.functions.StepFunction`
+            instances will be returned.
 
         Examples
         --------

--- a/sksurv/tree/tree.py
+++ b/sksurv/tree/tree.py
@@ -406,7 +406,7 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
-        return_array : boolean
+        return_array : boolean, default: False
             If set, return an array with the cumulative hazard rate
             for each `self.event_times_`, otherwise an array of
             :class:`sksurv.functions.StepFunction`.
@@ -415,8 +415,8 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
         -------
         cum_hazard : ndarray
             If `return_array` is set, an array with the cumulative hazard rate
-            for each `self.event_times_`, otherwise an array of
-            :class:`sksurv.functions.StepFunction` will be returned.
+            for each `self.event_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
 
         Examples
         --------
@@ -472,7 +472,7 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
-        return_array : boolean
+        return_array : boolean, default: False
             If set, return an array with the probability
             of survival for each `self.event_times_`,
             otherwise an array of :class:`sksurv.functions.StepFunction`.
@@ -480,10 +480,10 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
         Returns
         -------
         survival : ndarray
-            If `return_array` is set, an array with the probability
-            of survival for each `self.event_times_`,
-            otherwise an array of :class:`sksurv.functions.StepFunction`
-            will be returned.
+            If `return_array` is set, an array with the probability of
+            survival for each `self.event_times_`, otherwise an array of
+            length `n_samples` of :class:`sksurv.functions.StepFunction`
+            instances will be returned.
 
         Examples
         --------

--- a/tests/test_pandas_inputs.py
+++ b/tests/test_pandas_inputs.py
@@ -1,35 +1,10 @@
-from importlib import import_module
-import inspect
-from os.path import dirname
-import pkgutil
-
 import numpy
 from numpy.testing import assert_array_equal
 import pandas
 import pytest
 
-import sksurv
-from sksurv.base import SurvivalAnalysisMixin
 from sksurv.datasets import load_whas500
-
-
-def is_survival_mixin(x):
-    return inspect.isclass(x) and x is not SurvivalAnalysisMixin and issubclass(x, SurvivalAnalysisMixin)
-
-
-def all_survival_estimators():
-    root = dirname(sksurv.__file__)
-    all_classes = []
-    for _importer, modname, _ispkg in pkgutil.walk_packages(path=[root], prefix="sksurv."):
-        # meta-estimators require base estimators
-        if modname.startswith("sksurv.meta"):
-            continue
-        module = import_module(modname)
-        for _name, cls in inspect.getmembers(module, is_survival_mixin):
-            if inspect.isabstract(cls):
-                continue
-            all_classes.append(cls)
-    return set(all_classes)
+from sksurv.testing import all_survival_estimators
 
 
 @pytest.mark.parametrize("estimator_cls", all_survival_estimators())

--- a/tests/test_survival_function.py
+++ b/tests/test_survival_function.py
@@ -1,0 +1,32 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+import pytest
+
+from sksurv.linear_model import CoxnetSurvivalAnalysis
+from sksurv.testing import all_survival_estimators
+
+
+def all_survival_function_estimators():
+    estimators = set()
+    for cls in all_survival_estimators():
+        if hasattr(cls, "predict_survival_function"):
+            if issubclass(cls, CoxnetSurvivalAnalysis):
+                est = cls(fit_baseline_model=True)
+            else:
+                est = cls()
+            estimators.add(est)
+    return estimators
+
+
+@pytest.mark.parametrize("estimator", all_survival_function_estimators())
+def test_survival_functions(estimator, make_whas500):
+    data = make_whas500(to_numeric=True)
+
+    estimator.fit(data.x[150:], data.y[150:])
+    fns_cls = estimator.predict_survival_function(data.x[:150])
+    fns_arr = estimator.predict_survival_function(data.x[:150], return_array=True)
+
+    times = estimator.event_times_
+    arr = np.row_stack([fn(times) for fn in fns_cls])
+
+    assert_array_almost_equal(arr, fns_arr)


### PR DESCRIPTION
**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #268
- [x] py.test passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Adds `return_array` to `predict_survival_function` and `predict_cumulative_hazard_function`.