### PR TITLE
Fix install requirements for ARM64 on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,19 @@ requires = [
     "wheel",
     "setuptools_scm[toml]>=6.4",
     "Cython>=0.29.16",
-    "numpy==1.17.3; python_version=='3.8' and platform_system!='AIX'",
-    "numpy==1.19.3; python_version=='3.9'",
-    "numpy==1.21.4; python_version=='3.10'",
+
+    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
+    # (first version with arm64 wheels available)
+    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+
+    # default numpy requirements
+    "numpy==1.17.3; python_version=='3.8' and platform_machine != 'arm64'",
+    "numpy==1.19.3; python_version=='3.9' and platform_machine != 'arm64'",
+    "numpy==1.21.6; python_version=='3.10'",
     "numpy; python_version>'3.10'",
+
+    # scikit-learn requirements
     "scikit-learn~=1.1.0; python_version<='3.9'",
     "scikit-learn~=1.1.0; python_version=='3.10'",
     "scikit-learn; python_version>'3.10'",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #313
- [x] py.test passes

**What does this implement/fix? Explain your changes**
Raise install requirement on macOS with ARM64 to numpy 1.21.0, which is the first version that provides wheels for it.