### PR TITLE
CI: Remove deprecated set-output command

### DIFF
--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -33,9 +33,9 @@ jobs:
           echo "NUMPY_VERSION=${NUMPY_VERSION}" >> $GITHUB_ENV
           echo "SKLEARN_VERSION=${SKLEARN_VERSION}" >> $GITHUB_ENV
           echo "NO_SLOW=${NO_SLOW}" >> $GITHUB_ENV
-          echo "::set-output name=py_version::$(cut -d'.' -f 1-2 <<< ${CONDA_PYTHON_VERSION})"
-          echo "::set-output name=requirements::ci/deps/${{ matrix.config }}.sh"
-          echo "::set-output name=conda_pkgs::$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")"
+          echo "py_version=$(cut -d'.' -f 1-2 <<< ${CONDA_PYTHON_VERSION})" >> $GITHUB_OUTPUT
+          echo "requirements=ci/deps/${{ matrix.config }}.sh" >> $GITHUB_OUTPUT
+          echo "conda_pkgs=$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")" >> $GITHUB_OUTPUT
       - name: Cache downloaded packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/macos-workflow.yaml
+++ b/.github/workflows/macos-workflow.yaml
@@ -33,9 +33,9 @@ jobs:
           echo "NUMPY_VERSION=${NUMPY_VERSION}" >> $GITHUB_ENV
           echo "SKLEARN_VERSION=${SKLEARN_VERSION}" >> $GITHUB_ENV
           echo "NO_SLOW=${NO_SLOW}" >> $GITHUB_ENV
-          echo "::set-output name=py_version::$(cut -d'.' -f 1-2 <<< ${CONDA_PYTHON_VERSION})"
-          echo "::set-output name=requirements::ci/deps/${{ matrix.config }}.sh"
-          echo "::set-output name=conda_pkgs::$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")"
+          echo "py_version=$(cut -d'.' -f 1-2 <<< ${CONDA_PYTHON_VERSION})" >> $GITHUB_OUTPUT
+          echo "requirements=ci/deps/${{ matrix.config }}.sh" >> $GITHUB_OUTPUT
+          echo "conda_pkgs=$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")" >> $GITHUB_OUTPUT
       - name: Cache downloaded packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nbval-workflow.yaml
+++ b/.github/workflows/nbval-workflow.yaml
@@ -24,8 +24,8 @@ jobs:
           echo "NUMPY_VERSION=${NUMPY_VERSION}" >> $GITHUB_ENV
           echo "SKLEARN_VERSION=${SKLEARN_VERSION}" >> $GITHUB_ENV
           echo "NO_SLOW=${NO_SLOW}" >> $GITHUB_ENV
-          echo "::set-output name=requirements::ci/deps/${DEPS_CONFIG}.sh"
-          echo "::set-output name=conda_pkgs::$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")"
+          echo "requirements=ci/deps/${DEPS_CONFIG}.sh" >> $GITHUB_OUTPUT
+          echo "conda_pkgs=$(${CONDA}/bin/python -c "from conda.base.context import context; print(context.pkgs_dirs[0])")" >> $GITHUB_OUTPUT
       - name: Cache downloaded packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/wheels-workflow.yaml
+++ b/.github/workflows/wheels-workflow.yaml
@@ -26,11 +26,11 @@ jobs:
         shell: bash
         run: |
           if [ ${{ runner.os }} = 'Linux' ]; then
-            echo "::set-output name=build_platform::manylinux"
+            echo "build_platform=manylinux" >> $GITHUB_OUTPUT
           elif [ ${{ runner.os }} = 'macOS' ]; then
-            echo "::set-output name=build_platform::macosx"
+            echo "build_platform=macosx" >> $GITHUB_OUTPUT
           elif [ ${{ runner.os }} = 'Windows' ]; then
-            echo "::set-output name=build_platform::win_amd64"
+            echo "build_platform=win_amd64" >> $GITHUB_OUTPUT
           fi
 
       - name: Build wheels


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
