### PR TITLE
Update readthedocs to use Ubuntu 22.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ python:
       path: .
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Update to the latest Ubuntu version supported by read the docs.