### PR TITLE
[Docs] Feature selection states wrong number of best features.

### DIFF
--- a/doc/user_guide/00-introduction.ipynb
+++ b/doc/user_guide/00-introduction.ipynb
@@ -1226,7 +1226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The results show that it is sufficient to select the 3 most predictive features."
+    "The results show that it is sufficient to select the 5 most predictive features."
    ]
   },
   {


### PR DESCRIPTION
**What does this implement/fix? Explain your changes**
It seems that the grid CV concluded that 5 features provided the best model, but the text after that output stated 3 instead of 5.
Or, Celltype is considered one feature?
In this case, maybe emphasizing this will make things clearer for new learners.

This is a simple one digit change in the docs.