### PR TITLE
remove almost-unused local variable in _get_comparable

### DIFF
--- a/sksurv/metrics.py
+++ b/sksurv/metrics.py
@@ -93,8 +93,7 @@ def _get_comparable(event_indicator, event_time, order):
     i = 0
     while i < n_samples - 1:
         time_i = event_time[order[i]]
-        start = i + 1
-        end = start
+        end = i + 1
         while end < n_samples and event_time[order[end]] == time_i:
             end += 1
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] pytest passes
- [X] code is well formatted

**What does this implement/fix? Explain your changes**

Reading the code I noticed that the `start` local variable isn't really used and removing it would make the code marginally easier to read, though that's subjective of course.