### PR TITLE
set self.criterion in SurvivalTree.fit

### DIFF
--- a/sksurv/tree/tree.py
+++ b/sksurv/tree/tree.py
@@ -229,14 +229,15 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
         self.n_classes_ = np.ones(self.n_outputs_, dtype=np.intp) * 2
 
         # Build tree
-        self.criterion = LogrankCriterion(self.n_outputs_, n_samples, self.event_times_)
+        self.criterion = "logrank"
+        criterion = LogrankCriterion(self.n_outputs_, n_samples, self.event_times_)
 
         SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
 
         splitter = self.splitter
         if not isinstance(self.splitter, Splitter):
             splitter = SPLITTERS[self.splitter](
-                self.criterion,
+                criterion,
                 self.max_features_,
                 params["min_samples_leaf"],
                 params["min_weight_leaf"],

--- a/sksurv/tree/tree.py
+++ b/sksurv/tree/tree.py
@@ -229,14 +229,14 @@ class SurvivalTree(BaseEstimator, SurvivalAnalysisMixin):
         self.n_classes_ = np.ones(self.n_outputs_, dtype=np.intp) * 2
 
         # Build tree
-        criterion = LogrankCriterion(self.n_outputs_, n_samples, self.event_times_)
+        self.criterion = LogrankCriterion(self.n_outputs_, n_samples, self.event_times_)
 
         SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
 
         splitter = self.splitter
         if not isinstance(self.splitter, Splitter):
             splitter = SPLITTERS[self.splitter](
-                criterion,
+                self.criterion,
                 self.max_features_,
                 params["min_samples_leaf"],
                 params["min_weight_leaf"],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] pytest passes
- [ ] tests are included
- [X] code is well formatted
- [ ] documentation renders correctly

**What does this implement/fix? Explain your changes**

An `AttributeError: 'SurvivalTree' object has no attribute 'criterion'` error is encountered as mentioned in #110 and #133 issues. Setting the `criterion` in the `fit` method would allow plotting of the tree, with the caveat that the tree structure is visible but the `impurity` and `value` values are `inf` and arrays.

Code snippet:

```
import numpy as np
import sklearn.tree
import sksurv.tree
import sksurv.util

X = np.array([[80, 20], [70, 30], [60, 40], [50, 50], [40, 60], [30, 70], [20, 80]])
y = sksurv.util.Surv.from_arrays(time=(1, 2, 3, 4, 5, 6, 7),
                                 event=(True, True, True, False, False, False, False))

st = sksurv.tree.SurvivalTree()
st.fit(X, y)

sklearn.tree.plot_tree(st, feature_names=["one", "two"])
```