### PR TITLE
Fix broken links in 00-introduction.ipynb with nbsphinx 0.9.2

### DIFF
--- a/doc/user_guide/00-introduction.ipynb
+++ b/doc/user_guide/00-introduction.ipynb
@@ -28,7 +28,7 @@
     "6. [Multivariate Survival Models](#Multivariate-Survival-Models)\n",
     "7. [Measuring the Performance of Survival Models](#Measuring-the-Performance-of-Survival-Models)\n",
     "8. [Feature Selection: Which Variable is Most Predictive?](#Feature-Selection:-Which-Variable-is-Most-Predictive?)\n",
-    "9. [What's next?](#What%27s-next?)"
+    "9. [What's next?](#What's-next?)"
    ]
   },
   {

--- a/doc/user_guide/00-introduction.ipynb
+++ b/doc/user_guide/00-introduction.ipynb
@@ -21,7 +21,7 @@
     "## Table of Contents\n",
     "\n",
     "1. [What is Survival Analysis?](#What-is-Survival-Analysis?)\n",
-    "2. [The Veterans' Administration Lung Cancer Trial](#The-Veterans%27-Administration-Lung-Cancer-Trial)\n",
+    "2. [The Veterans' Administration Lung Cancer Trial](#The-Veterans%E2%80%99-Administration-Lung-Cancer-Trial)\n",
     "3. [Survival Data](#Survival-Data)\n",
     "4. [The Survival Function](#The-Survival-Function)\n",
     "5. [Considering other variables by stratification](#Considering-other-variables-by-stratification)\n",

--- a/doc/user_guide/00-introduction.ipynb
+++ b/doc/user_guide/00-introduction.ipynb
@@ -21,7 +21,7 @@
     "## Table of Contents\n",
     "\n",
     "1. [What is Survival Analysis?](#What-is-Survival-Analysis?)\n",
-    "2. [The Veterans' Administration Lung Cancer Trial](#The-Veterans%E2%80%99-Administration-Lung-Cancer-Trial)\n",
+    "2. [The Veterans' Administration Lung Cancer Trial](#The-Veterans'-Administration-Lung-Cancer-Trial)\n",
     "3. [Survival Data](#Survival-Data)\n",
     "4. [The Survival Function](#The-Survival-Function)\n",
     "5. [Considering other variables by stratification](#Considering-other-variables-by-stratification)\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dev = [
 # See https://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
 docs = [
     "ipython !=8.7.0",
-    "nbsphinx",
+    "nbsphinx>=0.9.2",
     "docutils",
     "setuptools-scm",
     "sphinx ~=4.4.0",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] closes #xxxx
- [ ] pytest passes
- [ ] tests are included
- [ ] code is well formatted
- [ ] documentation renders correctly

**What does this implement/fix? Explain your changes**

Recent CI runs fail with `Warning, treated as error: /home/runner/work/scikit-survival/scikit-survival/doc/user_guide/00-introduction.ipynb:35:undefined label: /user_guide/00-introduction.ipynb#the-veterans%27-administration-lung-cancer-trial` and experimentally the link on https://scikit-survival.readthedocs.io/en/stable/user_guide/00-introduction.html is broken. The https://scikit-survival.readthedocs.io/en/latest/user_guide/00-introduction.html links work though.
