### PR TITLE
Expose _predict_risk_score in Pipeline

### DIFF
--- a/sksurv/__init__.py
+++ b/sksurv/__init__.py
@@ -6,6 +6,8 @@ import sys
 from sklearn.pipeline import Pipeline, _final_estimator_has
 from sklearn.utils.metaestimators import available_if
 
+from .util import conditionalAvailableProperty
+
 
 def _get_version(name):
     try:
@@ -125,9 +127,15 @@ def predict_survival_function(self, X, **kwargs):
     return self.steps[-1][-1].predict_survival_function(Xt, **kwargs)
 
 
+@conditionalAvailableProperty(_final_estimator_has('_predict_risk_score'))
+def _predict_risk_score(self):
+    return self.steps[-1][-1]._predict_risk_score
+
+
 def patch_pipeline():
     Pipeline.predict_survival_function = predict_survival_function
     Pipeline.predict_cumulative_hazard_function = predict_cumulative_hazard_function
+    Pipeline._predict_risk_score = _predict_risk_score
 
 
 try:

--- a/sksurv/__init__.py
+++ b/sksurv/__init__.py
@@ -6,7 +6,7 @@ import sys
 from sklearn.pipeline import Pipeline, _final_estimator_has
 from sklearn.utils.metaestimators import available_if
 
-from .util import conditionalAvailableProperty
+from .util import property_available_if
 
 
 def _get_version(name):
@@ -127,7 +127,7 @@ def predict_survival_function(self, X, **kwargs):
     return self.steps[-1][-1].predict_survival_function(Xt, **kwargs)
 
 
-@conditionalAvailableProperty(_final_estimator_has('_predict_risk_score'))
+@property_available_if(_final_estimator_has("_predict_risk_score"))
 def _predict_risk_score(self):
     return self.steps[-1][-1]._predict_risk_score
 

--- a/sksurv/util.py
+++ b/sksurv/util.py
@@ -259,3 +259,84 @@ def safe_concat(objs, *args, **kwargs):
         concatenated[name] = pd.Categorical(concatenated[name], **params)
 
     return concatenated
+
+
+class _ConditionalAvailableProperty:
+    """Implements a conditional property using the descriptor protocol based on the property decorator.
+
+    The corresponding class in scikit-learn (_AvailableIfDescriptor) only supports callables. This
+    class adopts the property decorator as presented by the descriptor guide in the offical documentation.
+
+    The check is defined on the getter function. Setter, Deleter also need to be defined on the exposing clas
+s
+    if they are supposed to be available.
+
+    See Also
+    --------
+    sklearn.utils.available_if._AvailableIfDescriptor:
+    The original class in scikit-learn.
+    """
+
+    def __init__(self, check, fget=None, fset=None, fdel=None, doc=None):
+        self._check = check
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
+        self._name = ''
+
+    def _run_check(self, obj):
+        attr_err = AttributeError(
+            f"This {repr(obj)} has no attribute {repr(self._name)}"
+        )
+        if not self.check(obj):
+            raise attr_err
+
+    def __set_name__(self, owner, name):
+        self._name = name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        self._run_check(obj)
+        if self.fget is None:
+            raise AttributeError(f"property '{self._name}' has no getter")
+        return self.fget(obj)
+
+    def __set__(self, obj, value):
+        self._run_check(obj)
+        if self.fset is None:
+            raise AttributeError(f"property '{self._name}' has no setter")
+        self.fset(obj, value)
+
+    def __delete__(self, obj):
+        self._run_check(obj)
+        if self.fdel is None:
+            raise AttributeError(f"property '{self._name}' has no deleter")
+        self.fdel(obj)
+
+    @property
+    def check(self):
+        return self._check
+
+    def getter(self, fget):
+        prop = type(self)(self.check, fget, self.fset, self.fdel, self.__doc__)
+        prop._name = self._name
+        return prop
+
+    def setter(self, fset):
+        prop = type(self)(self.check, self.fget, fset, self.fdel, self.__doc__)
+        prop._name = self._name
+        return prop
+
+    def deleter(self, fdel):
+        prop = type(self)(self.check, self.fget, self.fset, fdel, self.__doc__)
+        prop._name = self._name
+        return prop
+
+
+def conditionalAvailableProperty(check):
+    prop = _ConditionalAvailableProperty(check=check)
+    return prop.getter

--- a/tests/test_aft.py
+++ b/tests/test_aft.py
@@ -1,7 +1,9 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
+from sklearn.pipeline import make_pipeline
 
+from sksurv.base import SurvivalAnalysisMixin
 from sksurv.linear_model import IPCRidge
 from sksurv.testing import assert_cindex_almost_equal
 
@@ -51,3 +53,21 @@ class TestIPCRidge:
         )
 
         assert model.score(x_test, y_test) == 0.66925817946226107
+
+    @staticmethod
+    def test_pipeline_score(make_whas500):
+        whas500 = make_whas500()
+        pipe = make_pipeline(IPCRidge())
+        pipe.fit(whas500.x[:400], whas500.y[:400])
+
+        x_test = whas500.x[400:]
+        y_test = whas500.y[400:]
+        p = pipe.predict(x_test)
+        assert_cindex_almost_equal(
+            y_test["fstat"],
+            y_test["lenfol"],
+            -p,
+            (0.66925817946226107, 2066, 1021, 0, 1),
+        )
+
+        assert SurvivalAnalysisMixin.score(pipe, x_test, y_test) == 0.66925817946226107

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ import pandas.testing as tm
 import pytest
 
 from sksurv.testing import FixtureParameterFactory
-from sksurv.util import Surv, safe_concat
+from sksurv.util import Surv, conditionalAvailableProperty, safe_concat
 
 
 class ConcatCasesFactory(FixtureParameterFactory):
@@ -369,3 +369,58 @@ def test_from_dataframe(args, expected, expected_error):
 
     if expected is not None:
         assert_array_equal(y, expected)
+
+
+def test_cond_avail_property():
+    class WithCondProp:
+        def __init__(self, val):
+            self.avail = False
+            self._prop = val
+
+        @conditionalAvailableProperty(lambda self: self.avail)
+        def prop(self):
+            return self._prop
+
+        @prop.setter
+        def prop(self, new):
+            self._prop = new
+
+        @prop.deleter
+        def prop(self):
+            self.avail = False
+
+    testval = 43
+    msg = "has no attribute 'prop'"
+
+    assert WithCondProp.prop is not None
+
+    test_obj = WithCondProp(testval)
+    with pytest.raises(AttributeError, match=msg):
+        _ = test_obj.prop
+    with pytest.raises(AttributeError, match=msg):
+        test_obj.prop = testval - 1
+    with pytest.raises(AttributeError, match=msg):
+        del test_obj.prop
+    test_obj.avail = True
+    assert test_obj.prop == testval
+    test_obj.prop = testval - 2
+    assert test_obj.prop == testval - 2
+    del test_obj.prop
+    assert test_obj.avail is False
+    with pytest.raises(AttributeError, match=msg):
+        _ = test_obj.prop
+    with pytest.raises(AttributeError, match=msg):
+        test_obj.prop = testval - 3
+    with pytest.raises(AttributeError, match=msg):
+        del test_obj.prop
+
+    test_obj.avail = True
+    WithCondProp.prop.fget = None
+    with pytest.raises(AttributeError, match="has no getter"):
+        _ = test_obj.prop
+    WithCondProp.prop.fset = None
+    with pytest.raises(AttributeError, match="has no setter"):
+        test_obj.prop = testval - 4
+    WithCondProp.prop.fdel = None
+    with pytest.raises(AttributeError, match="has no deleter"):
+        del test_obj.prop


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #324
- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Adds conditional property `_predict_risk_score` to `sklearn.pipeline.Pipeline` if the final estimator of the pipeline has such property.

Superseeds  #327