### PR TITLE
Add predict_(cumulative_hazard|survival)_function to Stacking

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,6 +213,7 @@ def linkcode_resolve(domain, info):
     Adapted from scipy.
     """
     import sksurv
+    from sksurv.util import _PropertyAvailableIfDescriptor
 
     if domain != "py":
         return None
@@ -230,6 +231,9 @@ def linkcode_resolve(domain, info):
             obj = getattr(obj, part)
         except AttributeError:
             return None
+
+    if isinstance(obj, _PropertyAvailableIfDescriptor):
+        obj = obj.fget  # link to wrapped method
 
     try:
         fn = inspect.getsourcefile(obj)

--- a/sksurv/meta/stacking.py
+++ b/sksurv/meta/stacking.py
@@ -286,6 +286,32 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
         Xt = self._predict_estimators(X)
         return self.final_estimator_.predict_log_proba(Xt)
 
+    @available_if(_meta_estimator_has("predict_cumulative_hazard_function"))
+    def predict_cumulative_hazard_function(self, X, return_array=False):
+        """Perform prediction.
+
+        Only available if the meta estimator has a predict_cumulative_hazard_function method.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Data with samples to predict.
+
+        return_array : boolean, default: False
+            If set, return an array with the cumulative hazard rate
+            for each `self.unique_times_`, otherwise an array of
+            :class:`sksurv.functions.StepFunction`.
+
+        Returns
+        -------
+        cum_hazard : ndarray
+            If `return_array` is set, an array with the cumulative hazard rate
+            for each `self.unique_times_`, otherwise an array of length `n_samples`
+            of :class:`sksurv.functions.StepFunction` instances will be returned.
+        """
+        Xt = self._predict_estimators(X)
+        return self.final_estimator_.predict_cumulative_hazard_function(Xt, return_array)
+
     @available_if(_meta_estimator_has("predict_survival_function"))
     def predict_survival_function(self, X, return_array=False):
         """Perform prediction.

--- a/sksurv/meta/stacking.py
+++ b/sksurv/meta/stacking.py
@@ -70,6 +70,9 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during ``fit``. Defined only when `X`
         has feature names that are all strings.
+
+    unique_times_ : array of shape = (n_unique_times,)
+        Unique time points.
     """
 
     _parameter_constraints = {

--- a/sksurv/meta/stacking.py
+++ b/sksurv/meta/stacking.py
@@ -246,7 +246,7 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
     def predict_proba(self, X):
         """Perform prediction.
 
-        Only available of the meta estimator has a predict_proba method.
+        Only available if the meta estimator has a predict_proba method.
 
         Parameters
         ----------
@@ -268,7 +268,7 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
     def predict_log_proba(self, X):
         """Perform prediction.
 
-        Only available of the meta estimator has a predict_log_proba method.
+        Only available if the meta estimator has a predict_log_proba method.
 
         Parameters
         ----------
@@ -285,3 +285,31 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
         """
         Xt = self._predict_estimators(X)
         return self.final_estimator_.predict_log_proba(Xt)
+
+    @available_if(_meta_estimator_has("predict_survival_function"))
+    def predict_survival_function(self, X, return_array=False):
+        """Perform prediction.
+
+        Only available if the meta estimator has a predict_survival_function method.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Data with samples to predict.
+
+        Returns
+        -------
+        survival : ndarray
+            If `return_array` is set, an array with the probability of
+            survival for each `self.unique_times_`, otherwise an array of
+            length `n_samples` of :class:`sksurv.functions.StepFunction`
+            instances will be returned.
+
+        return_array : boolean, default: False
+            If set, return an array with the probability
+            of survival for each `self.unique_times_`,
+            otherwise an array of :class:`sksurv.functions.StepFunction`.
+
+        """
+        Xt = self._predict_estimators(X)
+        return self.final_estimator_.predict_survival_function(Xt, return_array)

--- a/sksurv/meta/stacking.py
+++ b/sksurv/meta/stacking.py
@@ -16,6 +16,7 @@ from sklearn.utils._param_validation import HasMethods
 from sklearn.utils.metaestimators import _BaseComposition, available_if
 
 from ..base import SurvivalAnalysisMixin
+from ..util import property_available_if
 
 
 def _meta_estimator_has(attr):
@@ -285,6 +286,10 @@ class Stacking(MetaEstimatorMixin, SurvivalAnalysisMixin, _BaseComposition):
         """
         Xt = self._predict_estimators(X)
         return self.final_estimator_.predict_log_proba(Xt)
+
+    @property_available_if(_meta_estimator_has("unique_times_"))
+    def unique_times_(self):
+        return self.meta_estimator.unique_times_
 
     @available_if(_meta_estimator_has("predict_cumulative_hazard_function"))
     def predict_cumulative_hazard_function(self, X, return_array=False):

--- a/tests/test_forest.py
+++ b/tests/test_forest.py
@@ -8,7 +8,7 @@ from sklearn.pipeline import make_pipeline
 from sksurv.datasets import load_breast_cancer
 from sksurv.ensemble import ExtraSurvivalTrees, RandomSurvivalForest
 from sksurv.preprocessing import OneHotEncoder
-from sksurv.testing import assert_cindex_almost_equal
+from sksurv.testing import assert_chf_properties, assert_cindex_almost_equal, assert_survival_function_properties
 from sksurv.tree import SurvivalTree
 
 FORESTS = [
@@ -72,15 +72,7 @@ def test_fit_predict_chf(make_whas500, forest_cls):
     chf = forest.predict_cumulative_hazard_function(whas500.x, return_array=True)
     assert chf.shape == (500, forest.unique_times_.shape[0])
 
-    assert np.isfinite(chf).all()
-    assert np.all(chf >= 0.0)
-
-    vals, counts = np.unique(chf[:, 0], return_counts=True)
-    assert vals[0] == 0.0
-    assert np.max(counts) == counts[0]
-
-    d = np.apply_along_axis(np.diff, 1, chf)
-    assert (d >= 0).all()
+    assert_chf_properties(chf)
 
 
 @pytest.mark.parametrize("forest_cls", FORESTS)
@@ -95,16 +87,7 @@ def test_fit_predict_surv(make_whas500, forest_cls):
     surv = forest.predict_survival_function(whas500.x, return_array=True)
     assert surv.shape == (500, forest.unique_times_.shape[0])
 
-    assert np.isfinite(surv).all()
-    assert np.all(surv >= 0.0)
-    assert np.all(surv <= 1.0)
-
-    vals, counts = np.unique(surv[:, 0], return_counts=True)
-    assert vals[-1] == 1.0
-    assert np.max(counts) == counts[-1]
-
-    d = np.apply_along_axis(np.diff, 1, surv)
-    assert (d <= 0).all()
+    assert_survival_function_properties(surv)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stacking.py
+++ b/tests/test_stacking.py
@@ -239,6 +239,28 @@ class TestStackingSurvivalAnalysis:
             getattr(meta, method)()  # pylint: disable=pointless-statement
 
     @staticmethod
+    def test_unique_times(make_whas500):
+        meta = Stacking(
+            _PredictDummy(),
+            [("coxph", CoxPHSurvivalAnalysis()), ("svm", FastSurvivalSVM(random_state=0))],
+            probabilities=False,
+        )
+        with pytest.raises(AttributeError, match="'_PredictDummy' object has no attribute 'unique_times_'"):
+            meta.unique_times_  # pylint: disable=pointless-statement
+
+        meta = Stacking(
+            CoxPHSurvivalAnalysis(),
+            [("rsf", RandomSurvivalForest(random_state=0)), ("svm", FastSurvivalSVM(random_state=0))],
+            probabilities=False,
+        )
+        with pytest.raises(AttributeError, match="'BreslowEstimator' object has no attribute 'unique_times_'"):
+            meta.unique_times_  # pylint: disable=pointless-statement
+
+        whas500 = make_whas500(with_mean=False, with_std=False, to_numeric=True)
+        meta.fit(whas500.x_data_frame, whas500.y)
+        assert 395 == len(meta.unique_times_)
+
+    @staticmethod
     def test_predict_cumulative_hazard_function(make_whas500):
         whas500 = make_whas500(with_mean=False, with_std=False, to_numeric=True)
 

--- a/tests/test_stacking.py
+++ b/tests/test_stacking.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 import pandas as pd
 import pytest
 from sklearn.base import BaseEstimator
@@ -13,7 +13,7 @@ from sksurv.ensemble import RandomSurvivalForest
 from sksurv.linear_model import CoxPHSurvivalAnalysis
 from sksurv.meta import MeanEstimator, Stacking
 from sksurv.svm import FastSurvivalSVM
-from sksurv.testing import assert_cindex_almost_equal
+from sksurv.testing import assert_chf_properties, assert_cindex_almost_equal, assert_survival_function_properties
 
 
 class _NoFitEstimator(BaseEstimator):
@@ -275,14 +275,7 @@ class TestStackingSurvivalAnalysis:
 
         assert cum_hazard.shape == (whas500.x_data_frame.shape[0], meta.estimators_[0].unique_times_.shape[0])
 
-        assert np.isfinite(cum_hazard).all()
-        assert np.all(cum_hazard >= 0.0)
-
-        _, counts = np.unique(cum_hazard[:, 0], return_counts=True)
-        assert np.max(counts) == counts[-1]
-
-        d = np.apply_along_axis(np.diff, 1, cum_hazard)
-        assert (d >= 0).all()
+        assert_chf_properties(cum_hazard)
 
     @staticmethod
     def test_predict_survival_function(make_whas500):
@@ -299,16 +292,7 @@ class TestStackingSurvivalAnalysis:
 
         assert surv.shape == (whas500.x_data_frame.shape[0], meta.estimators_[0].unique_times_.shape[0])
 
-        assert np.isfinite(surv).all()
-        assert np.all(surv >= 0.0)
-        assert np.all(surv <= 1.0)
-
-        vals, counts = np.unique(surv[:, 0], return_counts=True)
-        assert_almost_equal(vals[-1], 1.0, decimal=4)
-        assert np.max(counts) == counts[-1]
-
-        d = np.apply_along_axis(np.diff, 1, surv)
-        assert (d <= 0).all()
+        assert_survival_function_properties(surv)
 
     @staticmethod
     def test_score(whas_data_with_estimator):

--- a/tests/test_stacking.py
+++ b/tests/test_stacking.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
 import pandas as pd
 import pytest
 from sklearn.base import BaseEstimator
@@ -9,6 +9,7 @@ from sklearn.metrics import accuracy_score, roc_auc_score
 from sklearn.svm import SVC
 from sklearn.tree import DecisionTreeClassifier
 
+from sksurv.ensemble import RandomSurvivalForest
 from sksurv.linear_model import CoxPHSurvivalAnalysis
 from sksurv.meta import MeanEstimator, Stacking
 from sksurv.svm import FastSurvivalSVM
@@ -223,8 +224,8 @@ class TestStackingSurvivalAnalysis:
         assert_cindex_almost_equal(y["fstat"], y["lenfol"], p, (0.7848807, 58983, 16166, 0, 14))
 
     @staticmethod
-    @pytest.mark.parametrize("method", ["predict_proba", "predict_log_proba"])
-    def test_predict_proba(method):
+    @pytest.mark.parametrize("method", ["predict_proba", "predict_log_proba", "predict_survival_function"])
+    def test_predict_variants(method):
         meta = Stacking(
             _PredictDummy(),
             [("coxph", CoxPHSurvivalAnalysis()), ("svm", FastSurvivalSVM(random_state=0))],
@@ -233,6 +234,32 @@ class TestStackingSurvivalAnalysis:
 
         with pytest.raises(AttributeError, match=f"'_PredictDummy' object has no attribute '{method}'"):
             getattr(meta, method)()  # pylint: disable=pointless-statement
+
+    @staticmethod
+    def test_predict_survival_function(make_whas500):
+        whas500 = make_whas500(with_mean=False, with_std=False, to_numeric=True)
+
+        meta = Stacking(
+            CoxPHSurvivalAnalysis(),
+            [("rsf", RandomSurvivalForest(random_state=0)), ("svm", FastSurvivalSVM(random_state=0))],
+            probabilities=False,
+        )
+        meta.fit(whas500.x_data_frame, whas500.y)
+
+        surv = meta.predict_survival_function(whas500.x_data_frame, return_array=True)
+
+        assert surv.shape == (whas500.x_data_frame.shape[0], meta.estimators_[0].unique_times_.shape[0])
+
+        assert np.isfinite(surv).all()
+        assert np.all(surv >= 0.0)
+        assert np.all(surv <= 1.0)
+
+        vals, counts = np.unique(surv[:, 0], return_counts=True)
+        assert_almost_equal(vals[-1], 1.0, decimal=4)
+        assert np.max(counts) == counts[-1]
+
+        d = np.apply_along_axis(np.diff, 1, surv)
+        assert (d <= 0).all()
 
     @staticmethod
     def test_score(whas_data_with_estimator):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #368
- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Adds `predict_survival_function` and `predict_cumulative_hazard_function` to `sksurv.meta.Stacking`.

Supersedes #385.