### PR TITLE
Add scikit-learn 1.3 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ requires = [
     "numpy; python_version>'3.11'",
 
     # scikit-learn requirements
-    "scikit-learn>=1.2.0; python_version<='3.9'",
-    "scikit-learn>=1.2.0; python_version=='3.10'",
-    "scikit-learn>=1.2.0; python_version=='3.11'",
+    "scikit-learn~=1.2.0; python_version<='3.9'",
+    "scikit-learn~=1.2.0; python_version=='3.10'",
+    "scikit-learn~=1.2.0; python_version=='3.11'",
     "scikit-learn; python_version>'3.11'",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ requires = [
     "numpy; python_version>'3.11'",
 
     # scikit-learn requirements
-    "scikit-learn~=1.2.0; python_version<='3.9'",
-    "scikit-learn~=1.2.0; python_version=='3.10'",
-    "scikit-learn~=1.2.0; python_version=='3.11'",
+    "scikit-learn>=1.2.0; python_version<='3.9'",
+    "scikit-learn>=1.2.0; python_version=='3.10'",
+    "scikit-learn>=1.2.0; python_version=='3.11'",
     "scikit-learn; python_version>'3.11'",
 ]
 build-backend = "setuptools.build_meta"
@@ -63,7 +63,7 @@ dependencies = [
     "osqp !=0.6.0,!=0.6.1",
     "pandas >=1.0.5",
     "scipy >=1.3.2",
-    "scikit-learn >=1.2.0,<1.3",
+    "scikit-learn >=1.2.0,<1.4",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ requires = [
     "numpy; python_version>'3.11'",
 
     # scikit-learn requirements
-    "scikit-learn~=1.2.0; python_version<='3.9'",
-    "scikit-learn~=1.2.0; python_version=='3.10'",
-    "scikit-learn~=1.2.0; python_version=='3.11'",
+    "scikit-learn~=1.2; python_version<='3.9'",
+    "scikit-learn~=1.2; python_version=='3.10'",
+    "scikit-learn~=1.2; python_version=='3.11'",
     "scikit-learn; python_version>'3.11'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
**What does this implement/fix? Explain your changes**
Scikit-survival is currently limited to scikit-learn 1.2, 1.3 has been out since June.