### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ this unique characteristic of such a dataset into account.
 Requirements
 ============
 
-- Python 3.8 or later
+- Python 3.9 or later
 - ecos
 - joblib
 - numexpr

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -84,7 +84,7 @@ Dependencies
 
 The current minimum dependencies to run scikit-survival are:
 
-- Python 3.8 or later
+- Python 3.9 or later
 - ecos
 - joblib
 - numexpr

--- a/doc/user_guide/00-introduction.ipynb
+++ b/doc/user_guide/00-introduction.ipynb
@@ -1277,7 +1277,7 @@
     "pipe.set_params(**gcv.best_params_)\n",
     "pipe.fit(data_x, data_y)\n",
     "\n",
-    "encoder, transformer, final_estimator = [s[1] for s in pipe.steps]\n",
+    "encoder, transformer, final_estimator = (s[1] for s in pipe.steps)\n",
     "pd.Series(final_estimator.coef_, index=encoder.encoded_columns_[transformer.get_support()])"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,9 @@ requires = [
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with arm64 wheels available)
-    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
     "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.8' and platform_machine != 'arm64'",
     "numpy==1.19.3; python_version=='3.9' and platform_machine != 'arm64'",
     "numpy==1.21.6; python_version=='3.10'",
     "numpy==1.23.2; python_version=='3.11'",
@@ -33,7 +31,7 @@ authors = [
     {name = "Sebastian Pölsterl", email = "sebp@k-d-w.org"}
 ]
 license = {file = "COPYING"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -46,7 +44,6 @@ classifiers = [
     "Programming Language :: Cython",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -125,7 +122,7 @@ namespaces = false
 [tool.black]
 line-length = 120
 extend-exclude = "sksurv/linear_model/src/eigen"
-target-version = ["py38"]
+target-version = ["py39"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/sksurv/datasets/base.py
+++ b/sksurv/datasets/base.py
@@ -1,4 +1,3 @@
-import sys
 import warnings
 
 import numpy as np
@@ -22,10 +21,8 @@ __all__ = [
 
 
 def _get_data_path(name):
-    if sys.version_info >= (3, 9):
-        from importlib.resources import files
-    else:
-        from importlib_resources import files
+    from importlib.resources import files
+
     return files(__package__) / "data" / name
 
 

--- a/tests/test_forest.py
+++ b/tests/test_forest.py
@@ -161,7 +161,7 @@ def test_fit_warm_start(make_whas500, forest_cls):
     forest.fit(whas500.x, whas500.y)
 
     assert len(forest.estimators_) == 11
-    assert all((e.max_depth == 2 for e in forest.estimators_))
+    assert all(e.max_depth == 2 for e in forest.estimators_)
 
     forest.set_params(warm_start=True)
     with pytest.warns(UserWarning, match="Warm-start fitting without increasing n_estimators does not fit new trees."):
@@ -177,7 +177,7 @@ def test_fit_warm_start(make_whas500, forest_cls):
     forest.fit(whas500.x, whas500.y)
 
     assert len(forest.estimators_) == 23
-    assert all((e.max_depth == 2 for e in forest.estimators_))
+    assert all(e.max_depth == 2 for e in forest.estimators_)
 
 
 @pytest.mark.parametrize("forest_cls", FORESTS)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -133,7 +133,7 @@ def test_loadarff_dataframe():
 def test_writearff(data_frame, relation_name, expectation, temp_file):
     writearff(data_frame, temp_file, relation_name=relation_name, index=False)
 
-    with open(temp_file.name, "r") as fp:
+    with open(temp_file.name) as fp:
         read_date = fp.readlines()
 
     assert expectation == read_date


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Remove support for Python 3.8 and require 3.9 or later.