### PR TITLE
Corrected kaplan_meier_estimator documentation to give correct default argument

### DIFF
--- a/sksurv/nonparametric.py
+++ b/sksurv/nonparametric.py
@@ -241,7 +241,7 @@ def kaplan_meier_estimator(
     conf_level : float, optional, default: 0.95
         The level for a two-sided confidence interval on the survival curves.
 
-    conf_type : None or {'log-log'}, optional, default: 'log-log'.
+    conf_type : None or {'log-log'}, optional, default: None.
         The type of confidence intervals to estimate.
         If `None`, no confidence intervals are estimated.
         If "log-log", estimate confidence intervals using

--- a/sksurv/nonparametric.py
+++ b/sksurv/nonparametric.py
@@ -421,7 +421,7 @@ class SurvivalFunctionEstimator(BaseEstimator):
     conf_level : float, optional, default: 0.95
         The level for a two-sided confidence interval on the survival curves.
 
-    conf_type : None or {'log-log'}, optional, default: 'log-log'.
+    conf_type : None or {'log-log'}, optional, default: None.
         The type of confidence intervals to estimate.
         If `None`, no confidence intervals are estimated.
         If "log-log", estimate confidence intervals using


### PR DESCRIPTION
Problem: kaplan_meier_estimator docstring shows conf_type default argument as log-log instead of None
Solution: Changed docstring to match code


**Checklist**

- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**

Was wondering why my code  wasn't working, turns out the wrong default argument is listed on the docs. This should fix it. Haven't checked for disparity between docs and code for other functions/classes but this is the only one I've had issues with so far.