### PR TITLE
Disable early stopping criteria

### DIFF
--- a/sksurv/linear_model/src/coxnet/coxnet.h
+++ b/sksurv/linear_model/src/coxnet/coxnet.h
@@ -249,13 +249,13 @@ void Coxnet<T, S, U>::fit(
         coef_path.col(i) = m_params.coef_x;
         dev_ratio_path[i] = 1. - (loglik_saturated - log_likelihood()) / deviance_null;
 
-        if (i >= Constants<Scalar>::MIN_ALPHAS()) {
-            /* abort if change in deviance ratio was small, compared to previous (larger) alpha */
-            if (dev_ratio_path[i - Constants<Scalar>::MIN_ALPHAS() + 1] / dev_ratio_path[i] > 0.999) {
-                ++i;
-                break;
-            }
-        }
+        // if (i >= Constants<Scalar>::MIN_ALPHAS()) {
+        //     /* abort if change in deviance ratio was small, compared to previous (larger) alpha */
+        //     if (dev_ratio_path[i - Constants<Scalar>::MIN_ALPHAS() + 1] / dev_ratio_path[i] > 0.999) {
+        //         ++i;
+        //         break;
+        //     }
+        // }
     }
 
     result.setNumberOfAlphas(i);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] closes #41 
- [x] <del>pytest passes</del> pytest (that were passing before) passes
- [x] tests are included (no tests added)
- [x] code is well formatted
- [ ] documentation renders correctly (this idk)

**What does this implement/fix? Explain your changes**
In `sksurv/linear_model/src/coxnet/coxnet.h` we find the `fit` method for the `CoxnetSurvivalAnalysis` class. This fits a model for the desired regularization path. The current implementation includes an early stop condition which stops fiting a model for the given alphas based on a deviance ratio. However it is desirable sometimes to fit the whole path (using all the alphas) even if the performance does not change significanly across alphas (see #41 for a more detailed explanation of the behaviour). The obvios solution is to get rid of the early stop condition (which is what I have done here by commentitg it out), however I think the better solution would be to include a boolean flag in the class definition that specifies if the user wishes or not to use this early stopping functionality. Sadly I do not have the time to implement such a solution. Please feel free to use this PR as a starting point.
