### PR TITLE
Fix/onehotencoder misses one category#508

### DIFF
--- a/sksurv/column.py
+++ b/sksurv/column.py
@@ -82,9 +82,9 @@ def _encode_categorical_series(series, allow_drop=True):
         return series
 
     names = []
-    for key in range(1, enc.shape[1]):
+    for key in range(0, enc.shape[1]):
         names.append(f"{series.name}={levels[key]}")
-    series = pd.DataFrame(enc[:, 1:], columns=names, index=series.index)
+    series = pd.DataFrame(enc[:, 0:], columns=names, index=series.index)
 
     return series
 


### PR DESCRIPTION
**Checklist**

- [x] closes #508 
- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

This fix is about categories missing in the results when using sksurv.column.encode_categorical. The first category was ignored for each column (caused by indexing starting from 1 instead of 0 in the _encode_categorical_series() method in column.py lines 85 and 87). The corresponding tests were written with data expecting these categories to be missing, hence they have been fixed as well. 
