### PR TITLE
chore(metrics): fixing and ending bracket typo in ValueError for check_times

### DIFF
--- a/sksurv/metrics.py
+++ b/sksurv/metrics.py
@@ -65,7 +65,7 @@ def _check_times(test_time, times):
 
     if times.max() >= test_time.max() or times.min() < test_time.min():
         raise ValueError(
-            f"all times must be within follow-up time of test data: [{test_time.min()}; {test_time.max()}["
+            f"all times must be within follow-up time of test data: [{test_time.min()}; {test_time.max()}]"
         )
 
     return times


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] code is well formatted

**What does this implement/fix? Explain your changes**
Fixing a minor typo in a `ValueError` for the `_check_times` validation function. Previous implementation yielded error:
```
ValueError: all times must be within follow-up time of test data: [3.0; 2880.0[
```

Corrected version:
```
ValueError: all times must be within follow-up time of test data: [3.0; 2880.0]
```
