### PR TITLE
CI: Use miniforge instead of miniconda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Installation
 ============
 
 The easiest way to install scikit-survival is to use
-`Anaconda <https://www.anaconda.com/docs/getting-started/anaconda/main>`_ by running::
+`conda-forge <https://conda-forge.org/docs/user/introduction/>`_ by running::
 
   conda install -c conda-forge scikit-survival
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,10 @@ platform:
 - x64
 
 install:
-  - ps: $env:CONDA_INSTALL_LOCN="$env:USERPROFILE\Miniconda3"
-  - ps: Invoke-WebRequest -Uri https://repo.anaconda.com/miniconda/Miniconda3-py313_25.3.1-1-Windows-x86_64.exe -OutFile Miniconda3.exe
-  - ps: ( Get-FileHash -Algorithm SHA256 Miniconda3.exe ).Hash -eq 'ea482f35b4861f047dc525c1e8dc645cc761a5460a121caf726dec098c5804de'
-  - ps: Start-Process Miniconda3.exe -Wait -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=1', '/D="$env:CONDA_INSTALL_LOCN"')
+  - ps: $env:CONDA_INSTALL_LOCN="$env:USERPROFILE\Miniforge3"
+  - ps: Invoke-WebRequest -Uri https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Windows-x86_64.exe -OutFile Miniforge.exe
+  - ps: ( Get-FileHash -Algorithm SHA256 Miniforge.exe ).Hash -eq 'b48cd98430170983076dfb51769a6d37668176f59bf3b59c4b21ac4c9bc24f39'
+  - ps: Start-Process Miniforge.exe -Wait -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=1', '/D="$env:CONDA_INSTALL_LOCN"')
   - ps: $env:Path += ";$env:CONDA_INSTALL_LOCN\Scripts;$env:CONDA_INSTALL_LOCN\Library\bin"
   - ps: conda init powershell
   - ps: conda config --set always_yes yes

--- a/ci/deps/requirements.yaml.tmpl
+++ b/ci/deps/requirements.yaml.tmpl
@@ -1,7 +1,6 @@
 name: sksurv-test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - coverage
   - cython>=3.0

--- a/ci/setup_conda.sh
+++ b/ci/setup_conda.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 RUNNER_OS="${1}"
 RUNNER_ARCH="${2}"
@@ -8,40 +9,42 @@ run_check_sha() {
     echo "${1}" | shasum -a 256 --check --strict -
 }
 
-if [[ "${CONDA:-}" = "" ]]; then
+if [[ "${MINIFORGE:-}" = "" ]]; then
     # download and install conda
-    MINICONDA_VERSION="Miniconda3-py313_25.3.1-1"
+    MINIFORGE_VERSION="25.3.0-3"
 
     if [[ "${RUNNER_OS}" = "macOS" ]] && [[ "${RUNNER_ARCH}" = "ARM64" ]]; then
-        MINICONDA_VERSION="${MINICONDA_VERSION}-MacOSX-arm64"
-        MINICONDA_HASH="d54b27ed4a6d3c31fedbad6f9f488377702196b0d8d89854e8e7d01f701f225b"
+        MINIFORGE_FILENAME="${MINIFORGE_VERSION}-MacOSX-arm64"
+        MINIFORGE_HASH="16205127ac2b5701881636229b7fe42e1f961007513b8673f8064da331e496a0"
     elif [[ "${RUNNER_OS}" = "macOS" ]] && [[ "${RUNNER_ARCH}" = "X64" ]]; then
-        MINICONDA_VERSION="${MINICONDA_VERSION}-MacOSX-x86_64"
-        MINICONDA_HASH="614c455b74d85abe98c2d0fb9b00628bbf2d48932ea4b49ec05b5c4bee7e9239"
+        MINIFORGE_FILENAME="${MINIFORGE_VERSION}-MacOSX-x86_64"
+        MINIFORGE_HASH="c562e11d8f9caca3dcfb9ba6d5043b9238975d271751e12c3fbfc2a472b4b8fb"
     elif [[ "${RUNNER_OS}" = "Linux" ]] && [[ "${RUNNER_ARCH}" = "X64" ]]; then
-        MINICONDA_VERSION="${MINICONDA_VERSION}-Linux-x86_64"
-        MINICONDA_HASH="53a86109463cfd70ba7acab396d416e623012914eee004729e1ecd6fe94e8c69"
+        MINIFORGE_FILENAME="${MINIFORGE_VERSION}-Linux-x86_64"
+        MINIFORGE_HASH="1b57f8cb991982063f79b56176881093abb1dc76d73fda32102afde60585b5a1"
     else
         echo "Unsupported OS or ARCH: ${RUNNER_OS} ${RUNNER_ARCH}"
         exit 1
     fi
 
-    export CONDA="${GITHUB_WORKSPACE}/miniconda3"
+    export MINIFORGE="${GITHUB_WORKSPACE}/miniforge"
 
-    mkdir -p "${CONDA}" && \
-    curl "https://repo.anaconda.com/miniconda/${MINICONDA_VERSION}.sh" -o "${CONDA}/miniconda.sh" && \
-    run_check_sha "${MINICONDA_HASH}  ${CONDA}/miniconda.sh" && \
-    bash "${CONDA}/miniconda.sh" -b -u -p "${CONDA}" && \
-    rm -rf "${CONDA}/miniconda.sh" || exit 1
+    mkdir -p "${MINIFORGE}" && \
+    curl --fail -L "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_FILENAME}.sh" -o "${MINIFORGE}/miniforge.sh" && \
+    run_check_sha "${MINIFORGE_HASH}  ${MINIFORGE}/miniforge.sh" && \
+    bash "${MINIFORGE}/miniforge.sh" -b -u -p "${MINIFORGE}" && \
+    rm -rf "${MINIFORGE}/miniforge.sh" || exit 1
 
-    echo "CONDA=${CONDA}" >> "${GITHUB_ENV}"
+    echo "MINIFORGE=${MINIFORGE}" >> "${GITHUB_ENV}"
 fi
 
-"${CONDA}/bin/conda" config --set always_yes yes && \
-"${CONDA}/bin/conda" config --set changeps1 no && \
-"${CONDA}/bin/conda" config --set auto_update_conda false && \
-"${CONDA}/bin/conda" config --set show_channel_urls true || \
+"${MINIFORGE}/bin/conda" config --set always_yes yes && \
+"${MINIFORGE}/bin/conda" config --set changeps1 no && \
+"${MINIFORGE}/bin/conda" config --set auto_update_conda false && \
+"${MINIFORGE}/bin/conda" config --set show_channel_urls true || \
 exit 1
+
+"${MINIFORGE}/bin/conda" config --show-sources
 
 # The directory in which packages are located.
 # https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/settings.html#pkgs-dirs-specify-package-directories
@@ -51,9 +54,9 @@ fi
 sudo chown -R "${USER}" "${CONDA_PKGS_DIR}" || \
 exit 1
 
-sudo "${CONDA}/bin/conda" update -q -n base conda && \
-sudo chown -R "${USER}" "${CONDA}" || \
+sudo "${MINIFORGE}/bin/conda" update -q -n base conda && \
+sudo chown -R "${USER}" "${MINIFORGE}" || \
 exit 1
 
-export PATH="${CONDA}/bin:${PATH}"
-echo "${CONDA}/bin" >> "${GITHUB_PATH}"
+export PATH="${MINIFORGE}/bin:${PATH}"
+echo "${MINIFORGE}/bin" >> "${GITHUB_PATH}"

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -16,9 +16,9 @@ python ci/render-requirements.py ci/deps/requirements.yaml.tmpl > environment.ya
 
 conda env create -n sksurv-test --file environment.yaml
 
-echo "numpy ${CI_NUMPY_VERSION:?}" > "${CONDA:?}/envs/sksurv-test/conda-meta/pinned"
-echo "pandas ${CI_PANDAS_VERSION:?}" >> "${CONDA:?}/envs/sksurv-test/conda-meta/pinned"
-echo "scikit-learn ${CI_SKLEARN_VERSION:?}" >> "${CONDA:?}/envs/sksurv-test/conda-meta/pinned"
+echo "numpy ${CI_NUMPY_VERSION:?}" > "${MINIFORGE:?}/envs/sksurv-test/conda-meta/pinned"
+echo "pandas ${CI_PANDAS_VERSION:?}" >> "${MINIFORGE:?}/envs/sksurv-test/conda-meta/pinned"
+echo "scikit-learn ${CI_SKLEARN_VERSION:?}" >> "${MINIFORGE:?}/envs/sksurv-test/conda-meta/pinned"
 
 # Useful for debugging any issues with conda
 conda info -a

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -167,7 +167,7 @@ please re-run the install command from the :ref:`setup-dev-environment` section.
 If you are new to Cython you may find the project's documentation on
 :ref:`debugging <cython:debugging>` and :ref:`profiling <cython:profiling>` helpful.
 
-.. _conda: https://www.anaconda.com/docs/getting-started/miniconda/install
+.. _conda: https://conda-forge.org/download/
 .. _uv: https://docs.astral.sh/uv/getting-started/installation/
 .. _Cython: https://cython.org
 .. _Git: https://git-scm.com/


### PR DESCRIPTION
Avoids licensing issues related to Anaconda's default channels by removing default conda channels, which require accepting Anaconda Terms of Service

<!--
♥ Thanks for contributing a pull request! ♥

Please ensure you have taken a look at the contribution guidelines:
https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Anaconda started requiring explicit agreement to the Terms of Service (see https://www.anaconda.com/blog/conda-anaconda-tos-plugin). This breaks automated CI. By switching to Miniforge, we do not use Anaconda's default channels, which avoids the license issue.