### PR TITLE
corrected typo -- changed non-singular to singular

### DIFF
--- a/doc/user_guide/coxnet.ipynb
+++ b/doc/user_guide/coxnet.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Penalized Cox Models\n",
     "\n",
-    "[Cox's proportional hazard's model](https://en.wikipedia.org/wiki/Proportional_hazards_model) is often an appealing model, because its coefficients can be interpreted in terms of hazard ratio, which often provides valuable insight. However, if we want to estimate the coefficients of many features, the standard Cox model falls apart, because internally it tries to invert a matrix that becomes non-singular due to correlations among features.\n",
+    "[Cox's proportional hazard's model](https://en.wikipedia.org/wiki/Proportional_hazards_model) is often an appealing model, because its coefficients can be interpreted in terms of hazard ratio, which often provides valuable insight. However, if we want to estimate the coefficients of many features, the standard Cox model falls apart, because internally it tries to invert a matrix that becomes singular due to correlations among features.\n",
     "\n",
     "## Ridge\n",
     "\n",


### PR DESCRIPTION
when too many features are correlated, the matrix COX tries to invert becomes singular

<!--
♥ Thanks for contributing a pull request! ♥

Please ensure you have taken a look at the contribution guidelines:
https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] closes #xxxx
- [ ] pytest passes
- [ ] tests are included
- [ ] code is well formatted
- [ ] documentation renders correctly

**What does this implement/fix? Explain your changes**
