### PR TITLE
Support pandas string dtype

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Requirements
 - numexpr
 - numpy
 - osqp
-- pandas 1.4.0 or later
+- pandas 2.0.0 or later
 - scikit-learn 1.6 or 1.7
 - scipy
 - C/C++ compiler

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ image: Visual Studio 2022
 environment:
   # see https://www.appveyor.com/docs/build-environment/#python
   matrix:
-    - CONDA_PY: "310"
     - CONDA_PY: "311"
     - CONDA_PY: "312"
     - CONDA_PY: "313"

--- a/ci/deps/py310.sh
+++ b/ci/deps/py310.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 export CI_PYTHON_VERSION='3.10.*'
-export CI_PANDAS_VERSION='1.5.*'
+export CI_PANDAS_VERSION='2.0.*'
 export CI_NUMPY_VERSION='1.25.*'
 export CI_SKLEARN_VERSION='1.6.*'
 export CI_NO_SLOW=false

--- a/ci/deps/py311.sh
+++ b/ci/deps/py311.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 export CI_PYTHON_VERSION='3.11.*'
-export CI_PANDAS_VERSION='2.0.*'
+export CI_PANDAS_VERSION='2.1.*'
 export CI_NUMPY_VERSION='1.26.*'
 export CI_SKLEARN_VERSION='1.6.*'
 export CI_NO_SLOW=true

--- a/ci/deps/requirements.yaml.tmpl
+++ b/ci/deps/requirements.yaml.tmpl
@@ -13,6 +13,7 @@ dependencies:
   - packaging
   - pandas={CI_PANDAS_VERSION}
   - pip
+  - pyarrow>=10.0.1
   - pytest
   - python={CI_PYTHON_VERSION}
   - scikit-learn=={CI_SKLEARN_VERSION}

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -99,7 +99,7 @@ The current minimum dependencies to run scikit-survival are:
 - numexpr
 - numpy
 - osqp
-- pandas 1.4.0 or later
+- pandas 2.0.0 or later
 - scikit-learn 1.6 or 1.7
 - scipy
 - C/C++ compiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "numexpr",
     "numpy",
     "osqp >=0.6.3,<1.0.0",
-    "pandas >=1.4.0",
+    "pandas >=2.0.0",
     "scipy >=1.3.2",
     "scikit-learn >=1.6.1,<1.8",
 ]

--- a/sksurv/compare.py
+++ b/sksurv/compare.py
@@ -117,7 +117,7 @@ def compare_survival(y, group_indicator, return_stats=False):
         table["expected"] = expected
         table["statistic"] = observed - expected
         table = pd.DataFrame.from_dict(table)
-        table.index = pd.Index(groups, name="group", dtype=groups.dtype)
+        table.index = pd.Index(groups, name="group")
         return chisq, pval, table, covar
 
     return chisq, pval

--- a/sksurv/datasets/base.py
+++ b/sksurv/datasets/base.py
@@ -116,7 +116,7 @@ def _loadarff_with_index(filename):
         if isinstance(dataset["index"].dtype, CategoricalDtype):
             # concatenating categorical index may raise TypeError
             # see https://github.com/pandas-dev/pandas/issues/14586
-            dataset["index"] = dataset["index"].astype(object)
+            dataset["index"] = dataset["index"].astype("str")
         dataset.set_index("index", inplace=True)
     return dataset
 

--- a/sksurv/io/arffread.py
+++ b/sksurv/io/arffread.py
@@ -12,6 +12,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_string_dtype
 from scipy.io.arff import loadarff as scipy_loadarff
 
 __all__ = ["loadarff"]
@@ -34,7 +35,8 @@ def _to_pandas(data, meta):
             data_dict[name] = pd.Categorical(raw, categories=attr_format, ordered=False)
         else:
             arr = data[name]
-            p = pd.Series(arr, dtype=arr.dtype)
+            dtype = "str" if is_string_dtype(arr.dtype) else arr.dtype
+            p = pd.Series(arr, dtype=dtype)
             data_dict[name] = p
 
     # currently, this step converts all pandas.Categorial columns back to pandas.Series

--- a/sksurv/io/arffwrite.py
+++ b/sksurv/io/arffwrite.py
@@ -15,7 +15,7 @@ import re
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import CategoricalDtype, is_object_dtype
+from pandas.api.types import CategoricalDtype, is_string_dtype
 
 _ILLEGAL_CHARACTER_PAT = re.compile(r"[^-_=\w\d\(\)<>\.]")
 
@@ -106,7 +106,7 @@ def _write_header(data, fp, relation_name, index):
         name = attribute_names[column]
         fp.write(f"@attribute {name}\t")
 
-        if isinstance(series.dtype, CategoricalDtype) or is_object_dtype(series):
+        if isinstance(series.dtype, CategoricalDtype) or is_string_dtype(series.dtype):
             _write_attribute_categorical(series, fp)
         elif np.issubdtype(series.dtype, np.floating):
             fp.write("real")

--- a/sksurv/preprocessing.py
+++ b/sksurv/preprocessing.py
@@ -10,7 +10,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from pandas.api.types import CategoricalDtype
+import pandas as pd
+from pandas.api.types import CategoricalDtype, is_string_dtype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import _check_feature_names, _check_feature_names_in, _check_n_features, check_is_fitted
 
@@ -128,7 +129,13 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         """
         _check_feature_names(self, X, reset=True)
         _check_n_features(self, X, reset=True)
-        columns_to_encode = X.select_dtypes(include=["object", "category"]).columns
+
+        def is_string_or_categorical_dtype(dtype):
+            return is_string_dtype(dtype) or isinstance(dtype, CategoricalDtype)
+
+        columns_to_encode = pd.Index(
+            [name for name, dtype in X.dtypes.items() if is_string_or_categorical_dtype(dtype)]
+        )
         x_dummy = self._encode(X, columns_to_encode)
 
         self.feature_names_ = columns_to_encode

--- a/sksurv/testing.py
+++ b/sksurv/testing.py
@@ -106,3 +106,10 @@ class FixtureParameterFactory:
                 values = func()
                 cases.append(pytest.param(*values, id=name))
         return cases
+
+    def get_cases_func(self):
+        cases = []
+        for name, func in inspect.getmembers(self):
+            if name.startswith("data_"):
+                cases.append(pytest.param(func, id=name))
+        return cases

--- a/sksurv/util.py
+++ b/sksurv/util.py
@@ -345,7 +345,7 @@ def safe_concat(objs, *args, **kwargs):
                         raise ValueError(f"categories for column {name} do not match")
                 else:
                     categories[name] = {"categories": s.cat.categories, "ordered": s.cat.ordered}
-                df[name] = df[name].astype(object)
+                df[name] = df[name].astype("str")
 
     concatenated = pd.concat(objs, *args, axis=axis, **kwargs)
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -5,7 +5,7 @@ import pandas.testing as tm
 import pytest
 
 from sksurv import column
-from sksurv.testing import FixtureParameterFactory
+from sksurv.testing import FixtureParameterFactory, get_pandas_infer_string_context
 
 
 class StandardizeCase(FixtureParameterFactory):
@@ -247,10 +247,10 @@ class EncodeCategoricalCases(CategoricalCases):
         return input_df, kwargs, expected_df
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
 @pytest.mark.parametrize("make_data_fn", EncodeCategoricalCases().get_cases_func())
-def test_encode_categorical(make_data_fn, infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+def test_encode_categorical(make_data_fn, infer_string_context):
+    with infer_string_context:
         inputs, kwargs, expected_df = make_data_fn()
         actual_df = column.encode_categorical(inputs, **kwargs)
         tm.assert_frame_equal(actual_df.isnull(), expected_df.isnull())
@@ -300,10 +300,10 @@ class CategoricalToNumeric(CategoricalCases):
         return input_df, expected
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
 @pytest.mark.parametrize("make_data_fn", CategoricalToNumeric().get_cases_func())
-def test_categorical_to_numeric(make_data_fn, infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+def test_categorical_to_numeric(make_data_fn, infer_string_context):
+    with infer_string_context:
         input_df, expected = make_data_fn()
         actual = column.categorical_to_numeric(input_df)
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -247,15 +247,18 @@ class EncodeCategoricalCases(CategoricalCases):
         return input_df, kwargs, expected_df
 
 
-@pytest.mark.parametrize("inputs,kwargs,expected_df", EncodeCategoricalCases().get_cases())
+@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("make_data_fn", EncodeCategoricalCases().get_cases_func())
 @pytest.mark.filterwarnings(
     "ignore:In a future version, the Index constructor will not infer numeric dtypes when "
     "passed object-dtype sequences \\(matching Series behavior\\):FutureWarning"
 )  # deprecated in pandas 1.4.0
-def test_encode_categorical(inputs, kwargs, expected_df):
-    actual_df = column.encode_categorical(inputs, **kwargs)
-    tm.assert_frame_equal(actual_df.isnull(), expected_df.isnull())
-    tm.assert_frame_equal(actual_df, expected_df, check_exact=True)
+def test_encode_categorical(make_data_fn, infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        inputs, kwargs, expected_df = make_data_fn()
+        actual_df = column.encode_categorical(inputs, **kwargs)
+        tm.assert_frame_equal(actual_df.isnull(), expected_df.isnull())
+        tm.assert_frame_equal(actual_df, expected_df, check_exact=True)
 
 
 def test_series_numeric():
@@ -301,11 +304,14 @@ class CategoricalToNumeric(CategoricalCases):
         return input_df, expected
 
 
-@pytest.mark.parametrize("input_df,expected", CategoricalToNumeric().get_cases())
-def test_categorical_to_numeric(input_df, expected):
-    actual = column.categorical_to_numeric(input_df)
+@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("make_data_fn", CategoricalToNumeric().get_cases_func())
+def test_categorical_to_numeric(make_data_fn, infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        input_df, expected = make_data_fn()
+        actual = column.categorical_to_numeric(input_df)
 
-    if isinstance(expected, pd.Series):
-        tm.assert_series_equal(actual, expected, check_exact=True)
-    else:
-        tm.assert_frame_equal(actual, expected, check_exact=True)
+        if isinstance(expected, pd.Series):
+            tm.assert_series_equal(actual, expected, check_exact=True)
+        else:
+            tm.assert_frame_equal(actual, expected, check_exact=True)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -249,10 +249,6 @@ class EncodeCategoricalCases(CategoricalCases):
 
 @pytest.mark.parametrize("infer_string", [False, True])
 @pytest.mark.parametrize("make_data_fn", EncodeCategoricalCases().get_cases_func())
-@pytest.mark.filterwarnings(
-    "ignore:In a future version, the Index constructor will not infer numeric dtypes when "
-    "passed object-dtype sequences \\(matching Series behavior\\):FutureWarning"
-)  # deprecated in pandas 1.4.0
 def test_encode_categorical(make_data_fn, infer_string):
     with pd.option_context("future.infer_string", infer_string):
         inputs, kwargs, expected_df = make_data_fn()

--- a/tests/test_coxph.py
+++ b/tests/test_coxph.py
@@ -793,7 +793,7 @@ class TestCoxPH:
 
         X["grade"] = pd.Series(
             pd.Categorical(
-                X["grade"].astype(object), categories=["intermediate", "poorly differentiated", "well differentiated"]
+                X["grade"].astype("str"), categories=["intermediate", "poorly differentiated", "well differentiated"]
             ),
             index=X.index,
             name="grade",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -12,7 +12,7 @@ import pytest
 
 import sksurv.datasets as sdata
 from sksurv.io import writearff
-from sksurv.testing import FixtureParameterFactory
+from sksurv.testing import FixtureParameterFactory, get_pandas_infer_string_context
 
 ARFF_CATEGORICAL_INDEX_1 = """@relation arff_categorical_index
 @attribute index {SampleOne,SampleTwo,SampleThree,SampleFour}
@@ -216,37 +216,37 @@ def assert_structured_array_dtype(arr, event, time, num_events):
 
 
 class TestLoadDatasets:
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_whas500(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_whas500(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_whas500()
             assert x.shape == (500, 14)
             assert y.shape == (500,)
             assert_structured_array_dtype(y, "fstat", "lenfol", 215)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_gbsg2(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_gbsg2(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_gbsg2()
             assert x.shape == (686, 8)
             assert y.shape == (686,)
             assert_structured_array_dtype(y, "cens", "time", 299)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_veterans_lung_cancer(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_veterans_lung_cancer(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_veterans_lung_cancer()
             assert x.shape == (137, 6)
             assert y.shape == (137,)
             assert_structured_array_dtype(y, "Status", "Survival_in_days", 128)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_aids(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_aids(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_aids(endpoint="aids")
             assert x.shape == (1151, 11)
             assert y.shape == (1151,)
@@ -264,19 +264,19 @@ class TestLoadDatasets:
             with pytest.raises(ValueError, match="endpoint must be 'aids' or 'death'"):
                 sdata.load_aids(endpoint="foobar")
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_breast_cancer(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_breast_cancer(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_breast_cancer()
             assert x.shape == (198, 80)
             assert y.shape == (198,)
             assert_structured_array_dtype(y, "e.tdm", "t.tdm", 51)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_load_flchain(infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_load_flchain(infer_string_context):
+        with infer_string_context:
             x, y = sdata.load_flchain()
             assert x.shape == (7874, 9)
             assert y.shape == (7874,)
@@ -430,10 +430,10 @@ class LoadArffFilesCases(FixtureParameterFactory):
         return args, kwargs, x_train, y_train, x_test, y_test
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
 @pytest.mark.parametrize("make_data_fn", LoadArffFilesCases().get_cases_func())
-def test_load_arff_files(make_data_fn, infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+def test_load_arff_files(make_data_fn, infer_string_context):
+    with infer_string_context:
         (
             args,
             kwargs,
@@ -511,10 +511,10 @@ class LoadArffFilesWithTempFileCases(FixtureParameterFactory):
         )
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
 @pytest.mark.parametrize("make_data_fn", LoadArffFilesWithTempFileCases().get_cases_func())
-def test_load_from_temp_file(make_data_fn, temp_file_pair, infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+def test_load_from_temp_file(make_data_fn, temp_file_pair, infer_string_context):
+    with infer_string_context:
         (
             args_train,
             kwargs_train,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -216,59 +216,71 @@ def assert_structured_array_dtype(arr, event, time, num_events):
 
 
 class TestLoadDatasets:
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_whas500():
-        x, y = sdata.load_whas500()
-        assert x.shape == (500, 14)
-        assert y.shape == (500,)
-        assert_structured_array_dtype(y, "fstat", "lenfol", 215)
+    def test_load_whas500(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_whas500()
+            assert x.shape == (500, 14)
+            assert y.shape == (500,)
+            assert_structured_array_dtype(y, "fstat", "lenfol", 215)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_gbsg2():
-        x, y = sdata.load_gbsg2()
-        assert x.shape == (686, 8)
-        assert y.shape == (686,)
-        assert_structured_array_dtype(y, "cens", "time", 299)
+    def test_load_gbsg2(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_gbsg2()
+            assert x.shape == (686, 8)
+            assert y.shape == (686,)
+            assert_structured_array_dtype(y, "cens", "time", 299)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_veterans_lung_cancer():
-        x, y = sdata.load_veterans_lung_cancer()
-        assert x.shape == (137, 6)
-        assert y.shape == (137,)
-        assert_structured_array_dtype(y, "Status", "Survival_in_days", 128)
+    def test_load_veterans_lung_cancer(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_veterans_lung_cancer()
+            assert x.shape == (137, 6)
+            assert y.shape == (137,)
+            assert_structured_array_dtype(y, "Status", "Survival_in_days", 128)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_aids():
-        x, y = sdata.load_aids(endpoint="aids")
-        assert x.shape == (1151, 11)
-        assert y.shape == (1151,)
-        assert_structured_array_dtype(y, "censor", "time", 96)
-        assert "censor_d" not in x.columns
-        assert "time_d" not in x.columns
+    def test_load_aids(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_aids(endpoint="aids")
+            assert x.shape == (1151, 11)
+            assert y.shape == (1151,)
+            assert_structured_array_dtype(y, "censor", "time", 96)
+            assert "censor_d" not in x.columns
+            assert "time_d" not in x.columns
 
-        x, y = sdata.load_aids(endpoint="death")
-        assert x.shape == (1151, 11)
-        assert y.shape == (1151,)
-        assert_structured_array_dtype(y, "censor_d", "time_d", 26)
-        assert "censor" not in x.columns
-        assert "time" not in x.columns
+            x, y = sdata.load_aids(endpoint="death")
+            assert x.shape == (1151, 11)
+            assert y.shape == (1151,)
+            assert_structured_array_dtype(y, "censor_d", "time_d", 26)
+            assert "censor" not in x.columns
+            assert "time" not in x.columns
 
-        with pytest.raises(ValueError, match="endpoint must be 'aids' or 'death'"):
-            sdata.load_aids(endpoint="foobar")
+            with pytest.raises(ValueError, match="endpoint must be 'aids' or 'death'"):
+                sdata.load_aids(endpoint="foobar")
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_breast_cancer():
-        x, y = sdata.load_breast_cancer()
-        assert x.shape == (198, 80)
-        assert y.shape == (198,)
-        assert_structured_array_dtype(y, "e.tdm", "t.tdm", 51)
+    def test_load_breast_cancer(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_breast_cancer()
+            assert x.shape == (198, 80)
+            assert y.shape == (198,)
+            assert_structured_array_dtype(y, "e.tdm", "t.tdm", 51)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_load_flchain():
-        x, y = sdata.load_flchain()
-        assert x.shape == (7874, 9)
-        assert y.shape == (7874,)
-        assert_structured_array_dtype(y, "death", "futime", 2169)
+    def test_load_flchain(infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            x, y = sdata.load_flchain()
+            assert x.shape == (7874, 9)
+            assert y.shape == (7874,)
+            assert_structured_array_dtype(y, "death", "futime", 2169)
 
 
 def _make_and_write_data(fp, n_samples, n_features, with_index, with_labels, seed, column_prefix="V"):
@@ -328,7 +340,7 @@ class LoadArffFilesCases(FixtureParameterFactory):
 
     def data_with_categorical_index_1(self):
         values = ["SampleOne", "SampleTwo", "SampleThree", "SampleFour"]
-        index = pd.Index(values, name="index", dtype=object)
+        index = pd.Index(values, name="index", dtype="str")
         x = pd.DataFrame.from_dict(
             {
                 "size": pd.Series(
@@ -365,7 +377,7 @@ class LoadArffFilesCases(FixtureParameterFactory):
 
     def data_with_categorical_index_2(self):
         values = ["ASampleOne", "ASampleTwo", "ASampleThree", "ASampleFour", "ASampleFive"]
-        index = pd.Index(values, name="index", dtype=object)
+        index = pd.Index(values, name="index", dtype="str")
 
         y = pd.DataFrame.from_dict(
             {
@@ -418,35 +430,35 @@ class LoadArffFilesCases(FixtureParameterFactory):
         return args, kwargs, x_train, y_train, x_test, y_test
 
 
-@pytest.mark.parametrize(
-    "args,kwargs,x_train_expected,y_train_expected,x_test_expected,y_test_expected",
-    LoadArffFilesCases().get_cases(),
-)
-def test_load_arff_files(
-    args,
-    kwargs,
-    x_train_expected,
-    y_train_expected,
-    x_test_expected,
-    y_test_expected,
-):
-    x_train, y_train, x_test, y_test = sdata.load_arff_files_standardized(
-        *args,
-        **kwargs,
-    )
+@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("make_data_fn", LoadArffFilesCases().get_cases_func())
+def test_load_arff_files(make_data_fn, infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        (
+            args,
+            kwargs,
+            x_train_expected,
+            y_train_expected,
+            x_test_expected,
+            y_test_expected,
+        ) = make_data_fn()
+        x_train, y_train, x_test, y_test = sdata.load_arff_files_standardized(
+            *args,
+            **kwargs,
+        )
 
-    tm.assert_frame_equal(x_train, x_train_expected, check_exact=True)
-    tm.assert_frame_equal(y_train, y_train_expected, check_exact=True)
+        tm.assert_frame_equal(x_train, x_train_expected, check_exact=True)
+        tm.assert_frame_equal(y_train, y_train_expected, check_exact=True)
 
-    if x_test_expected is None:
-        assert x_test is None
-    else:
-        tm.assert_frame_equal(x_test, x_test_expected, check_exact=True)
+        if x_test_expected is None:
+            assert x_test is None
+        else:
+            tm.assert_frame_equal(x_test, x_test_expected, check_exact=True)
 
-    if y_test_expected is None:
-        assert y_test is None
-    else:
-        tm.assert_frame_equal(y_test, y_test_expected, check_exact=True)
+        if y_test_expected is None:
+            assert y_test is None
+        else:
+            tm.assert_frame_equal(y_test, y_test_expected, check_exact=True)
 
 
 class LoadArffFilesWithTempFileCases(FixtureParameterFactory):
@@ -499,53 +511,60 @@ class LoadArffFilesWithTempFileCases(FixtureParameterFactory):
         )
 
 
-@pytest.mark.parametrize(
-    "args_train,kwargs_train,args_test,kwargs_test,errors_expected", LoadArffFilesWithTempFileCases().get_cases()
-)
-def test_load_from_temp_file(args_train, kwargs_train, args_test, kwargs_test, errors_expected, temp_file_pair):
-    tmp_train, tmp_test = temp_file_pair
+@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("make_data_fn", LoadArffFilesWithTempFileCases().get_cases_func())
+def test_load_from_temp_file(make_data_fn, temp_file_pair, infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        (
+            args_train,
+            kwargs_train,
+            args_test,
+            kwargs_test,
+            errors_expected,
+        ) = make_data_fn()
+        tmp_train, tmp_test = temp_file_pair
 
-    train_dataset = _make_and_write_data(tmp_train, *args_train, **kwargs_train)
-    if args_test is not None:
-        test_dataset = _make_and_write_data(tmp_test, *args_test, **kwargs_test)
-        path_testing = tmp_test.name
-        check_y_test = args_test[-2]  # with_label
-    else:
-        test_dataset = None
-        path_testing = None
-        check_y_test = False
-        tmp_test.close()
-
-    with ExitStack() as stack:
-        for error_expected in errors_expected:
-            stack.enter_context(error_expected)
-        x_train, y_train, x_test, y_test = sdata.load_arff_files_standardized(
-            tmp_train.name,
-            ["event", "time"],
-            1,
-            path_testing=path_testing,
-            survival=True,
-            standardize_numeric=False,
-            to_numeric=False,
-        )
-
-    if all(not isinstance(err, does_not_raise) for err in errors_expected):
-        return
-
-    cols = ["event", "time"]
-
-    x_true = train_dataset.drop(cols, axis=1)
-    assert_x_equal(x_true, x_train)
-    assert_y_equal(train_dataset, y_train)
-
-    if test_dataset is not None:
-        x_true = test_dataset
-        if check_y_test:
-            assert_y_equal(test_dataset, y_test)
-            x_true = test_dataset.drop(cols, axis=1)
+        train_dataset = _make_and_write_data(tmp_train, *args_train, **kwargs_train)
+        if args_test is not None:
+            test_dataset = _make_and_write_data(tmp_test, *args_test, **kwargs_test)
+            path_testing = tmp_test.name
+            check_y_test = args_test[-2]  # with_label
         else:
+            test_dataset = None
+            path_testing = None
+            check_y_test = False
+            tmp_test.close()
+
+        with ExitStack() as stack:
+            for error_expected in errors_expected:
+                stack.enter_context(error_expected)
+            x_train, y_train, x_test, y_test = sdata.load_arff_files_standardized(
+                tmp_train.name,
+                ["event", "time"],
+                1,
+                path_testing=path_testing,
+                survival=True,
+                standardize_numeric=False,
+                to_numeric=False,
+            )
+
+        if all(not isinstance(err, does_not_raise) for err in errors_expected):
+            return
+
+        cols = ["event", "time"]
+
+        x_true = train_dataset.drop(cols, axis=1)
+        assert_x_equal(x_true, x_train)
+        assert_y_equal(train_dataset, y_train)
+
+        if test_dataset is not None:
+            x_true = test_dataset
+            if check_y_test:
+                assert_y_equal(test_dataset, y_test)
+                x_true = test_dataset.drop(cols, axis=1)
+            else:
+                assert y_test is None
+            assert_x_equal(x_true, x_test)
+        else:
+            assert x_test is None
             assert y_test is None
-        assert_x_equal(x_true, x_test)
-    else:
-        assert x_test is None
-        assert y_test is None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -109,34 +109,42 @@ class DataFrameCases(FixtureParameterFactory):
         return data, "test_datetime", EXPECTED_DATETIME.copy()
 
 
-def test_loadarff_dataframe():
-    contents = "".join(EXPECTED_NO_QUOTES)
-    with StringIO(contents) as fp:
-        actual_df = loadarff(fp)
+@pytest.mark.parametrize("infer_string", [False, True])
+def test_loadarff_dataframe(infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        contents = "".join(EXPECTED_NO_QUOTES)
+        with StringIO(contents) as fp:
+            actual_df = loadarff(fp)
 
-    expected_df = pd.DataFrame.from_dict(
-        OrderedDict(
-            [
-                ("attr_nominal", pd.Series(pd.Categorical.from_codes([1, 2, 0, -1, 2, 1], ["beer", "water", "wine"]))),
-                (
-                    "attr_nominal_spaces",
-                    pd.Series(pd.Categorical.from_codes([2, 0, -1, 1, 0, 1], ["hard liquor", "mate", "red wine"])),
-                ),
-            ]
+        expected_df = pd.DataFrame.from_dict(
+            OrderedDict(
+                [
+                    (
+                        "attr_nominal",
+                        pd.Series(pd.Categorical.from_codes([1, 2, 0, -1, 2, 1], ["beer", "water", "wine"])),
+                    ),
+                    (
+                        "attr_nominal_spaces",
+                        pd.Series(pd.Categorical.from_codes([2, 0, -1, 1, 0, 1], ["hard liquor", "mate", "red wine"])),
+                    ),
+                ]
+            )
         )
-    )
 
-    tm.assert_frame_equal(expected_df, actual_df, check_exact=True)
+        tm.assert_frame_equal(expected_df, actual_df, check_exact=True)
 
 
-@pytest.mark.parametrize("data_frame,relation_name,expectation", DataFrameCases().get_cases())
-def test_writearff(data_frame, relation_name, expectation, temp_file):
-    writearff(data_frame, temp_file, relation_name=relation_name, index=False)
+@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("make_data_fn", DataFrameCases().get_cases_func())
+def test_writearff(make_data_fn, temp_file, infer_string):
+    with pd.option_context("future.infer_string", infer_string):
+        data_frame, relation_name, expectation = make_data_fn()
+        writearff(data_frame, temp_file, relation_name=relation_name, index=False)
 
-    with open(temp_file.name) as fp:
-        read_date = fp.readlines()
+        with open(temp_file.name) as fp:
+            read_date = fp.readlines()
 
-    assert expectation == read_date
+        assert expectation == read_date
 
 
 def test_writearff_unsupported_column_type(temp_file):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,7 +7,7 @@ import pandas.testing as tm
 import pytest
 
 from sksurv.io import loadarff, writearff
-from sksurv.testing import FixtureParameterFactory
+from sksurv.testing import FixtureParameterFactory, get_pandas_infer_string_context
 
 EXPECTED_1 = [
     "@relation test_nominal\n",
@@ -109,9 +109,9 @@ class DataFrameCases(FixtureParameterFactory):
         return data, "test_datetime", EXPECTED_DATETIME.copy()
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
-def test_loadarff_dataframe(infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
+def test_loadarff_dataframe(infer_string_context):
+    with infer_string_context:
         contents = "".join(EXPECTED_NO_QUOTES)
         with StringIO(contents) as fp:
             actual_df = loadarff(fp)
@@ -134,10 +134,10 @@ def test_loadarff_dataframe(infer_string):
         tm.assert_frame_equal(expected_df, actual_df, check_exact=True)
 
 
-@pytest.mark.parametrize("infer_string", [False, True])
+@pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
 @pytest.mark.parametrize("make_data_fn", DataFrameCases().get_cases_func())
-def test_writearff(make_data_fn, temp_file, infer_string):
-    with pd.option_context("future.infer_string", infer_string):
+def test_writearff(make_data_fn, temp_file, infer_string_context):
+    with infer_string_context:
         data_frame, relation_name, expectation = make_data_fn()
         writearff(data_frame, temp_file, relation_name=relation_name, index=False)
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -7,6 +7,7 @@ import pandas.testing as tm
 import pytest
 
 from sksurv.preprocessing import OneHotEncoder
+from sksurv.testing import get_pandas_infer_string_context
 
 
 def _encoded_data(data):
@@ -74,10 +75,10 @@ def create_string_data():
 
 
 class TestOneHotEncoder:
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_fit(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_fit(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, expected_data = create_categorical_data()
 
             t = OneHotEncoder().fit(data)
@@ -87,19 +88,19 @@ class TestOneHotEncoder:
 
             assert t.categories_ == {k: data[k].cat.categories for k in ["binary_1", "binary_2", "trinary", "many"]}
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_fit_transform(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_fit_transform(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, expected_data = create_categorical_data()
 
             actual_data = OneHotEncoder().fit_transform(data)
             tm.assert_frame_equal(actual_data, expected_data)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_transform(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_transform(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, _ = create_categorical_data()
 
             t = OneHotEncoder().fit(data)
@@ -111,10 +112,10 @@ class TestOneHotEncoder:
             actual_data = t.transform(data)
             tm.assert_frame_equal(actual_data, expected_data)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_get_feature_names_out(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_get_feature_names_out(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, expected_data = create_categorical_data()
 
             t = OneHotEncoder()
@@ -123,10 +124,10 @@ class TestOneHotEncoder:
             out_names = t.get_feature_names_out()
             assert_array_equal(out_names, expected_data.columns.values)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_get_feature_names_out_shuffled(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_get_feature_names_out_shuffled(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, _ = create_categorical_data()
             order = np.array(["binary_1", "N0", "N3", "trinary", "binary_2", "N1", "N2", "many"])
             expected_columns = np.array(
@@ -156,10 +157,10 @@ class TestOneHotEncoder:
             with pytest.raises(ValueError, match="input_features is not equal to feature_names_in_"):
                 t.get_feature_names_out(data.columns.tolist())
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_transform_other_columns(create_categorical_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_transform_other_columns(create_categorical_data, infer_string_context):
+        with infer_string_context:
             data, _ = create_categorical_data()
 
             t = OneHotEncoder().fit(data)
@@ -178,10 +179,10 @@ class TestOneHotEncoder:
             with pytest.raises(ValueError, match=r"2 features are missing from data: \['binary_1', 'many'\]"):
                 t.transform(data_renamed)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @staticmethod
-    def test_fit_transform_string_dtype(create_string_data, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_fit_transform_string_dtype(create_string_data, infer_string_context):
+        with infer_string_context:
             data, expected = create_string_data()
 
             t = OneHotEncoder()
@@ -200,11 +201,13 @@ class TestOneHotEncoder:
 
             tm.assert_frame_equal(transformed, expected)
 
-    @pytest.mark.parametrize("infer_string", [False, True])
+    @pytest.mark.parametrize("infer_string_context", get_pandas_infer_string_context())
     @pytest.mark.parametrize("n_rows_transform", [1, 2, 3, 4, 5, 10, 15, 20, 39])
     @staticmethod
-    def test_fit_transform_mixed_dtype(create_categorical_data, create_string_data, n_rows_transform, infer_string):
-        with pd.option_context("future.infer_string", infer_string):
+    def test_fit_transform_mixed_dtype(
+        create_categorical_data, create_string_data, n_rows_transform, infer_string_context
+    ):
+        with infer_string_context:
             data_cat, expected_cat = create_categorical_data(101)
             data_obj, expected_obj = create_string_data(101)
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -25,7 +25,7 @@ def _encoded_data(data):
 
 
 @pytest.fixture()
-def create_data():
+def create_categorical_data():
     def _create_data(n_samples=117):
         rnd = np.random.default_rng(51365192)
         data_num = pd.DataFrame(rnd.random((n_samples, 5)), columns=[f"N{i}" for i in range(5)])
@@ -52,7 +52,7 @@ def create_data():
 
 
 @pytest.fixture()
-def create_object_data():
+def create_string_data():
     def _create_data(n_samples=97):
         rnd = np.random.default_rng(882)
         data = pd.DataFrame(
@@ -74,149 +74,165 @@ def create_object_data():
 
 
 class TestOneHotEncoder:
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_fit(create_data):
-        data, expected_data = create_data()
+    def test_fit(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, expected_data = create_categorical_data()
 
-        t = OneHotEncoder().fit(data)
+            t = OneHotEncoder().fit(data)
 
-        assert t.feature_names_.tolist() == ["binary_1", "binary_2", "trinary", "many"]
-        assert set(t.encoded_columns_) == set(expected_data.columns)
+            assert t.feature_names_.tolist() == ["binary_1", "binary_2", "trinary", "many"]
+            assert set(t.encoded_columns_) == set(expected_data.columns)
 
-        assert t.categories_ == {k: data[k].cat.categories for k in ["binary_1", "binary_2", "trinary", "many"]}
+            assert t.categories_ == {k: data[k].cat.categories for k in ["binary_1", "binary_2", "trinary", "many"]}
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_fit_transform(create_data):
-        data, expected_data = create_data()
+    def test_fit_transform(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, expected_data = create_categorical_data()
 
-        actual_data = OneHotEncoder().fit_transform(data)
-        tm.assert_frame_equal(actual_data, expected_data)
+            actual_data = OneHotEncoder().fit_transform(data)
+            tm.assert_frame_equal(actual_data, expected_data)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_transform(create_data):
-        data, _ = create_data()
+    def test_transform(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, _ = create_categorical_data()
 
-        t = OneHotEncoder().fit(data)
-        data, expected_data = create_data(165)
-        actual_data = t.transform(data)
-        tm.assert_frame_equal(actual_data, expected_data)
+            t = OneHotEncoder().fit(data)
+            data, expected_data = create_categorical_data(165)
+            actual_data = t.transform(data)
+            tm.assert_frame_equal(actual_data, expected_data)
 
-        data = pd.concat((data.iloc[:, :2], data.iloc[:, 5:], data.iloc[:, 2:5]), axis=1)
-        actual_data = t.transform(data)
-        tm.assert_frame_equal(actual_data, expected_data)
+            data = pd.concat((data.iloc[:, :2], data.iloc[:, 5:], data.iloc[:, 2:5]), axis=1)
+            actual_data = t.transform(data)
+            tm.assert_frame_equal(actual_data, expected_data)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_get_feature_names_out(create_data):
-        data, expected_data = create_data()
+    def test_get_feature_names_out(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, expected_data = create_categorical_data()
 
-        t = OneHotEncoder()
-        t.fit(data)
+            t = OneHotEncoder()
+            t.fit(data)
 
-        out_names = t.get_feature_names_out()
-        assert_array_equal(out_names, expected_data.columns.values)
+            out_names = t.get_feature_names_out()
+            assert_array_equal(out_names, expected_data.columns.values)
 
+    @pytest.mark.parametrize("infer_string", [False, True])
     @staticmethod
-    def test_get_feature_names_out_shuffled(create_data):
-        data, _ = create_data()
-        order = np.array(["binary_1", "N0", "N3", "trinary", "binary_2", "N1", "N2", "many"])
-        expected_columns = np.array(
-            [
-                "binary_1=No",
-                "N0",
-                "N3",
-                "trinary=Blue",
-                "trinary=Red",
-                "binary_2=West",
-                "N1",
-                "N2",
-                "many=Two",
-                "many=Three",
-                "many=Four",
-                "many=Five",
-                "many=Six",
+    def test_get_feature_names_out_shuffled(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, _ = create_categorical_data()
+            order = np.array(["binary_1", "N0", "N3", "trinary", "binary_2", "N1", "N2", "many"])
+            expected_columns = np.array(
+                [
+                    "binary_1=No",
+                    "N0",
+                    "N3",
+                    "trinary=Blue",
+                    "trinary=Red",
+                    "binary_2=West",
+                    "N1",
+                    "N2",
+                    "many=Two",
+                    "many=Three",
+                    "many=Four",
+                    "many=Five",
+                    "many=Six",
+                ]
+            )
+
+            t = OneHotEncoder()
+            t.fit(data.loc[:, order])
+
+            out_names = t.get_feature_names_out()
+            assert_array_equal(out_names, expected_columns)
+
+            with pytest.raises(ValueError, match="input_features is not equal to feature_names_in_"):
+                t.get_feature_names_out(data.columns.tolist())
+
+    @pytest.mark.parametrize("infer_string", [False, True])
+    @staticmethod
+    def test_transform_other_columns(create_categorical_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, _ = create_categorical_data()
+
+            t = OneHotEncoder().fit(data)
+            data, _ = create_categorical_data(125)
+
+            data_renamed = data.rename(columns={"binary_1": "renamed_1"})
+            with pytest.raises(ValueError, match=r"1 features are missing from data: \['binary_1'\]"):
+                t.transform(data_renamed)
+
+            data_dropped = data.drop("trinary", axis=1)
+            error_msg = "X has 8 features, but OneHotEncoder is expecting 9 features as input"
+            with pytest.raises(ValueError, match=error_msg):
+                t.transform(data_dropped)
+
+            data_renamed = data.rename(columns={"binary_1": "renamed_1", "many": "too_many"})
+            with pytest.raises(ValueError, match=r"2 features are missing from data: \['binary_1', 'many'\]"):
+                t.transform(data_renamed)
+
+    @pytest.mark.parametrize("infer_string", [False, True])
+    @staticmethod
+    def test_fit_transform_string_dtype(create_string_data, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data, expected = create_string_data()
+
+            t = OneHotEncoder()
+            transformed = t.fit_transform(data)
+
+            assert t.feature_names_in_.tolist() == ["answer", "direction", "color"]
+
+            assert t.get_feature_names_out().tolist() == [
+                "answer=Yes",
+                "direction=North",
+                "direction=South",
+                "direction=West",
+                "color=Green",
+                "color=Red",
             ]
-        )
 
-        t = OneHotEncoder()
-        t.fit(data.loc[:, order])
+            tm.assert_frame_equal(transformed, expected)
 
-        out_names = t.get_feature_names_out()
-        assert_array_equal(out_names, expected_columns)
-
-        with pytest.raises(ValueError, match="input_features is not equal to feature_names_in_"):
-            t.get_feature_names_out(data.columns.tolist())
-
-    @staticmethod
-    def test_transform_other_columns(create_data):
-        data, _ = create_data()
-
-        t = OneHotEncoder().fit(data)
-        data, _ = create_data(125)
-
-        data_renamed = data.rename(columns={"binary_1": "renamed_1"})
-        with pytest.raises(ValueError, match=r"1 features are missing from data: \['binary_1'\]"):
-            t.transform(data_renamed)
-
-        data_dropped = data.drop("trinary", axis=1)
-        error_msg = "X has 8 features, but OneHotEncoder is expecting 9 features as input"
-        with pytest.raises(ValueError, match=error_msg):
-            t.transform(data_dropped)
-
-        data_renamed = data.rename(columns={"binary_1": "renamed_1", "many": "too_many"})
-        with pytest.raises(ValueError, match=r"2 features are missing from data: \['binary_1', 'many'\]"):
-            t.transform(data_renamed)
-
-    @staticmethod
-    def test_fit_transform_object_dtype(create_object_data):
-        data, expected = create_object_data()
-
-        t = OneHotEncoder()
-        transformed = t.fit_transform(data)
-
-        assert t.feature_names_in_.tolist() == ["answer", "direction", "color"]
-
-        assert t.get_feature_names_out().tolist() == [
-            "answer=Yes",
-            "direction=North",
-            "direction=South",
-            "direction=West",
-            "color=Green",
-            "color=Red",
-        ]
-
-        tm.assert_frame_equal(transformed, expected)
-
+    @pytest.mark.parametrize("infer_string", [False, True])
     @pytest.mark.parametrize("n_rows_transform", [1, 2, 3, 4, 5, 10, 15, 20, 39])
     @staticmethod
-    def test_fit_transform_mixed_dtype(create_data, create_object_data, n_rows_transform):
-        data_cat, expected_cat = create_data(101)
-        data_obj, expected_obj = create_object_data(101)
+    def test_fit_transform_mixed_dtype(create_categorical_data, create_string_data, n_rows_transform, infer_string):
+        with pd.option_context("future.infer_string", infer_string):
+            data_cat, expected_cat = create_categorical_data(101)
+            data_obj, expected_obj = create_string_data(101)
 
-        data = pd.concat((data_cat, data_obj), axis=1)
-        expected = pd.concat((expected_cat, expected_obj), axis=1)
+            data = pd.concat((data_cat, data_obj), axis=1)
+            expected = pd.concat((expected_cat, expected_obj), axis=1)
 
-        data_fit = data.iloc[n_rows_transform:]
-        data_transform = data.iloc[:n_rows_transform]
-        expected_transformed = expected.iloc[:n_rows_transform]
+            data_fit = data.iloc[n_rows_transform:]
+            data_transform = data.iloc[:n_rows_transform]
+            expected_transformed = expected.iloc[:n_rows_transform]
 
-        t = OneHotEncoder().fit(data_fit)
+            t = OneHotEncoder().fit(data_fit)
 
-        assert t.feature_names_in_.tolist() == [
-            "N0",
-            "N1",
-            "N2",
-            "N3",
-            "N4",
-            "binary_1",
-            "binary_2",
-            "trinary",
-            "many",
-            "answer",
-            "direction",
-            "color",
-        ]
+            assert t.feature_names_in_.tolist() == [
+                "N0",
+                "N1",
+                "N2",
+                "N3",
+                "N4",
+                "binary_1",
+                "binary_2",
+                "trinary",
+                "many",
+                "answer",
+                "direction",
+                "color",
+            ]
 
-        transformed = t.transform(data_transform)
-        assert transformed.shape[0] == n_rows_transform
+            transformed = t.transform(data_transform)
+            assert transformed.shape[0] == n_rows_transform
 
-        tm.assert_frame_equal(transformed, expected_transformed)
+            tm.assert_frame_equal(transformed, expected_transformed)


### PR DESCRIPTION
<!--
♥ Thanks for contributing a pull request! ♥

Please ensure you have taken a look at the contribution guidelines:
https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Add support for pandas StringDType which will replace the object dtype in pandas 3.
See https://pandas.pydata.org/docs/user_guide/migration-3-strings.html#string-migration-guide
