### PR TITLE
MNT: scikit-learn compat: remove criterion param from boosting

### DIFF
--- a/sksurv/ensemble/boosting.py
+++ b/sksurv/ensemble/boosting.py
@@ -664,13 +664,6 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         and an increase in bias.
         Values must be in the range `(0.0, 1.0]`.
 
-    criterion : {'friedman_mse', 'squared_error'}, optional, default: 'friedman_mse'
-        The function to measure the quality of a split. Supported criteria are
-        'friedman_mse' for the mean squared error with improvement score by
-        Friedman, 'squared_error' for mean squared error. The default value of
-        'friedman_mse' is generally the best as it can provide a better
-        approximation in some cases.
-
     min_samples_split : int or float, optional, default: 2
         The minimum number of samples required to split an internal node:
 
@@ -878,7 +871,6 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         learning_rate=0.1,
         n_estimators=100,
         subsample=1.0,
-        criterion="friedman_mse",
         min_samples_split=2,
         min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
@@ -899,7 +891,6 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
             loss=loss,
             learning_rate=learning_rate,
             n_estimators=n_estimators,
-            criterion=criterion,
             min_samples_split=min_samples_split,
             min_samples_leaf=min_samples_leaf,
             min_weight_fraction_leaf=min_weight_fraction_leaf,
@@ -997,7 +988,7 @@ class GradientBoostingSurvivalAnalysis(BaseGradientBoosting, SurvivalAnalysisMix
         for k in range(self.n_trees_per_iteration_):
             # induce regression tree on the negative gradient
             tree = DecisionTreeRegressor(
-                criterion=self.criterion,
+                criterion="squared_error",
                 splitter="best",
                 max_depth=self.max_depth,
                 min_samples_split=self.min_samples_split,


### PR DESCRIPTION
**Superseeded by PR #593**

Hi, I'm a scikit-learn contributor and I was looking at your repo because I was investigating https://github.com/scikit-learn/scikit-learn/issues/30554 that you opened. On the way, I stumbled on a few things that will crash with scikit-learn 1.9

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] pytest passes => no, not compatible with scikit-learn 1.8
- [x] code is well formatted

**What does this implement/fix? Explain your changes**

See: https://github.com/scikit-learn/scikit-learn/pull/32708

**Note:** this change is **NOT** compatible with scikit-learn 1.8.