### PR TITLE
fix: treat pandas Boolean as numeric in clinical_kernel

### DIFF
--- a/sksurv/kernels/clinical.py
+++ b/sksurv/kernels/clinical.py
@@ -12,7 +12,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 import pandas as pd
-from pandas.api.types import CategoricalDtype, is_numeric_dtype
+from pandas.api.types import CategoricalDtype, is_bool_dtype, is_numeric_dtype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import _check_feature_names, _check_n_features, check_is_fitted
 
@@ -39,7 +39,7 @@ def _get_continuous_and_ordinal_array(x):
     """Convert array from continuous and ordered categorical columns"""
     nominal_columns = x.select_dtypes(include=["object", "category"]).columns
     ordinal_columns = pd.Index([v for v in nominal_columns if x[v].cat.ordered])
-    continuous_columns = x.select_dtypes(include=[np.number]).columns
+    continuous_columns = x.select_dtypes(include=[np.number, "bool"]).columns
 
     x_num = x.loc[:, continuous_columns].to_numpy(dtype=np.float64)
     if len(ordinal_columns) > 0:
@@ -205,6 +205,8 @@ class ClinicalKernelTransform(BaseEstimator, TransformerMixin):
 
                 col = col.cat.codes
             elif is_numeric_dtype(dt):
+                if is_bool_dtype(dt):
+                    col = col.astype(np.uint8)
                 numeric_ranges.append(col.max() - col.min())
                 numeric_columns.append(i)
             else:

--- a/tests/test_clinical_kernel.py
+++ b/tests/test_clinical_kernel.py
@@ -319,6 +319,25 @@ Feature names unseen at fit time:
             t.prepare(data)
 
     @staticmethod
+    def test_bool_column_treated_as_numeric():
+        df_bool = pd.DataFrame(
+            {
+                "age": [20.0, 23.0, 26.0, 54.0, 100.0],
+                "event": [True, False, True, True, False],
+            }
+        )
+        df_uint = df_bool.assign(event=df_bool["event"].astype(np.uint8))
+
+        assert_array_almost_equal(clinical_kernel(df_bool), clinical_kernel(df_uint))
+
+        t_bool = ClinicalKernelTransform().fit(df_bool)
+        t_uint = ClinicalKernelTransform().fit(df_uint)
+        assert_array_almost_equal(t_bool._numeric_ranges, t_uint._numeric_ranges)
+        assert_array_almost_equal(t_bool.X_fit_, t_uint.X_fit_)
+        assert list(t_bool._numeric_columns) == [0, 1]
+        assert list(t_bool._nominal_columns) == []
+
+    @staticmethod
     def test_feature_mismatch(make_data):
         data, _ = make_data()
         x = data.iloc[:, :2]


### PR DESCRIPTION

**Checklist**

- [x] closes #589
- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly  <!-- no doc changes needed -->

**What does this implement/fix? Explain your changes**

Fixes the two divergent Boolean-handling bugs in `sksurv/kernels/clinical.py` described in #589:

1. **`clinical_kernel` silent drop.** `_get_continuous_and_ordinal_array` used `x.select_dtypes(include=[np.number])`, which excludes `np.bool_` because numpy treats it as a sibling of `np.number` rather than a subclass. Boolean columns matched neither the numeric nor the `object`/`category` filter, were silently dropped, and the resulting matrix was biased by `(n_features - n_bool_cols) / n_features` because normalization still used `x.shape[1]`.

   *Fix:* `select_dtypes(include=[np.number, "bool"])`.

2. **`ClinicalKernelTransform.fit` TypeError.** `_prepare_by_column_dtype` uses `pandas.api.types.is_numeric_dtype`, which returns `True` for Boolean, but `col.max() - col.min()` then failed with `TypeError: numpy boolean subtract` on numpy ≥ 1.25.

   *Fix:* cast Boolean columns to `np.uint8` before computing the range.

Both fixes align the pandas path with the policy already established in this codebase: `pandas.api.types.is_numeric_dtype(bool)` is `True`. After this change, `clinical_kernel(df)` and `clinical_kernel(df.astype({col: 'uint8'}))` produce identical kernel matrices, and `ClinicalKernelTransform().fit(df)` no longer crashes.

**Tests**

Added `TestClinicalKernel.test_bool_column_treated_as_numeric` asserting:
- `clinical_kernel` returns the same matrix for a Boolean column and its `uint8` equivalent.
- `ClinicalKernelTransform().fit` produces matching `_numeric_ranges` and `X_fit_` for both dtypes.
- The Boolean column is classified into `_numeric_columns`, not `_nominal_columns`.

Local verification:
- `pytest tests/` (including slow tests): 966 passed, 48 skipped, 0 failed.
- `pytest --doctest-modules --pyargs sksurv.kernels`: 1 passed.
- `ruff check` on the whole repo: clean.
- `pre-commit run` on changed files: all hooks pass.

**Behavior change note**

Users whose pipelines previously called `clinical_kernel` on a pandas frame containing Boolean columns will see different (corrected) kernel values after this change. The previous values were silently biased, so the change is a bug fix rather than an API change, but it may be worth flagging in the changelog.
