### PR TITLE
Ignore concat deprecation with polars 1.40.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,16 +145,13 @@ filterwarnings = [
     "ignore:scipy\\.optimize. The `disp` and `iprint` options of the L-BFGS-B solver are deprecated.*:DeprecationWarning",
     # deprecated since pandas 3.0.0
     "ignore:The copy keyword is deprecated and will be removed in a future version.*:DeprecationWarning",
-    # deprecated since polars 1.40.0: scikit-learn (pre-narwhals release) still
-    # routes feature-name extraction through ``X.__dataframe__()`` which polars
-    # has marked as deprecated. Once a sklearn release that uses narwhals
-    # (PR #31127, merged 2026-05-07) reaches our minimum, this entry can go.
-    "ignore:Support for the dataframe interchange protocol is deprecated.*:DeprecationWarning",
     # pandas 4 deprecates the implicit ``str``-via-``object`` inclusion in
     # ``DataFrame.select_dtypes``. Listing ``"str"`` explicitly would resolve
     # the deprecation but is rejected by pandas <= 3.x with ``TypeError``,
     # so the cross-version-safe call still emits the warning on pandas 4.
     "ignore:For backward compatibility, 'str' dtypes are included by select_dtypes.*",
+    # deprecated since polars 1.40.1
+    "ignore: the default behavior of `how='horizontal'` for `concat` is deprecated and will require equal heights in the next breaking release.*:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
<!--
♥ Thanks for contributing a pull request! ♥

Please ensure you have taken a look at the contribution guidelines:
https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

**Checklist**
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

**What does this implement/fix? Explain your changes**
Starting with polars 1.42.1, [polars.concat](https://docs.pola.rs/api/python/stable/reference/api/polars.concat.html#polars.concat) gives a DeprecationWarning when using `how="horizontal"`.

This commit ignores the warning.