### PR TITLE
Add support for clarabel QP solver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Requirements
 ============
 
 - Python 3.11 or later
+- clarabel
 - ecos
 - joblib
 - numexpr

--- a/ci/deps/requirements.yaml.tmpl
+++ b/ci/deps/requirements.yaml.tmpl
@@ -2,6 +2,7 @@ name: sksurv-test
 channels:
   - conda-forge
 dependencies:
+  - clarabel
   - coverage
   - cython>=3.1.4
   - ecos

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -94,6 +94,7 @@ Dependencies
 The current minimum dependencies to run scikit-survival are:
 
 - Python 3.11 or later
+- clarabel
 - ecos
 - joblib
 - numexpr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
+    "clarabel",
     "ecos",
     "joblib",
     "narwhals >=2.0.1",

--- a/sksurv/svm/minlip.py
+++ b/sksurv/svm/minlip.py
@@ -133,6 +133,54 @@ class _OsqpSolver(_QPSolver):
         return solver_opts
 
 
+class _ClarabelSolver(_QPSolver):
+    def __init__(self, max_iter, verbose):
+        super().__init__(
+            max_iter=max_iter,
+            verbose=verbose,
+        )
+
+    def solve(self, P, q, G, h):
+        import clarabel
+
+        P = sparse.csc_array(P)
+
+        settings = clarabel.DefaultSettings()
+        for k, v in self._get_options().items():
+            setattr(settings, k, v)
+
+        cones = [clarabel.NonnegativeConeT(G.shape[0])]
+        solver = clarabel.DefaultSolver(P, q, A=G, b=h, cones=cones, settings=settings)
+
+        results = solver.solve()
+
+        solved_codes = (
+            clarabel.SolverStatus.AlmostSolved,
+            clarabel.SolverStatus.Solved,
+        )
+
+        if results.status == clarabel.SolverStatus.MaxIterations:  # max iter reached
+            warnings.warn(
+                "clarabel solver did not converge: maximum iterations reached",
+                category=ConvergenceWarning,
+                stacklevel=2,
+            )
+        elif results.status not in solved_codes:  # pragma: no cover
+            raise RuntimeError(f"clarabel solver failed: {results.status}")
+
+        n_iter = results.iterations
+        x = np.asarray(results.x)
+        return x[np.newaxis], n_iter
+
+    def _get_options(self):
+        """Return a dictionary of clarabel solver options."""
+        solver_opts = {
+            "max_iter": self.max_iter or 200,
+            "verbose": self.verbose,
+        }
+        return solver_opts
+
+
 class _EcosSolver(_QPSolver):
     r"""
     Solves QP by expressing it as second-order cone program.
@@ -306,7 +354,7 @@ class MinlipSurvivalAnalysis(BaseEstimator, SurvivalAnalysisMixin):
         Weight of penalizing the hinge loss in the objective function.
         Must be greater than 0.
 
-    solver : {'ecos', 'osqp'}, optional, default: 'ecos'
+    solver : {'ecos', 'clarabel', 'osqp'}, optional, default: 'ecos'
         Which quadratic program solver to use.
 
     kernel : str or callable, optional, default: 'linear'
@@ -389,7 +437,7 @@ class MinlipSurvivalAnalysis(BaseEstimator, SurvivalAnalysisMixin):
     """
 
     _parameter_constraints = {
-        "solver": [StrOptions({"ecos", "osqp"})],
+        "solver": [StrOptions({"ecos", "clarabel", "osqp"})],
         "alpha": [Interval(numbers.Real, 0, None, closed="neither")],
         "kernel": [
             StrOptions(set(PAIRWISE_KERNEL_FUNCTIONS.keys()) | {"precomputed"}),
@@ -473,7 +521,15 @@ class MinlipSurvivalAnalysis(BaseEstimator, SurvivalAnalysisMixin):
 
         max_iter = self.max_iter
         if self.solver == "ecos":
+            warnings.warn(
+                "The 'ecos' solver will be removed in a future release. The new default solver will be 'clarabel'.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
             solver = _EcosSolver(max_iter=max_iter, verbose=self.verbose)
+        elif self.solver == "clarabel":
+            solver = _ClarabelSolver(max_iter=max_iter, verbose=self.verbose)
         elif self.solver == "osqp":
             solver = _OsqpSolver(max_iter=max_iter, verbose=self.verbose)
 

--- a/tests/test_minlip.py
+++ b/tests/test_minlip.py
@@ -245,12 +245,25 @@ def test_toy_create_difference_matrix(time, status, kind, expected_mat, expected
         assert_array_almost_equal(expected_diff, actual_diff)
 
 
+def _get_solver_context(solver):
+    from contextlib import nullcontext as does_not_warn
+
+    if solver == "ecos":
+        context = pytest.warns(FutureWarning, match="The 'ecos' solver will be removed in a future release")
+    else:
+        context = does_not_warn()
+    return context
+
+
 @pytest.fixture()
 def minlip_model_factory():
     def create_and_fit_model(solver, x, y, **kwargs):
         params = {"solver": solver, "alpha": 1, "pairs": "next"}
         params.update(kwargs)
-        return MinlipSurvivalAnalysis(**params).fit(x, y)
+
+        with _get_solver_context(solver):
+            est = MinlipSurvivalAnalysis(**params).fit(x, y)
+        return est
 
     return create_and_fit_model
 
@@ -265,7 +278,7 @@ def toy_data_standardized(toy_data, toy_test_data):
 
 class TestToyMinlipSurvivalAnalysis:
     @staticmethod
-    @pytest.mark.parametrize("solver,expected_iters", [("osqp", 75), ("ecos", 10)])
+    @pytest.mark.parametrize("solver,expected_iters", [("osqp", 75), ("clarabel", 9), ("ecos", 10)])
     def test_fit_alpha_2(minlip_model_factory, toy_data, solver, expected_iters):
         x, y = toy_data
         m = minlip_model_factory(solver, x, y, alpha=2.0)
@@ -287,14 +300,14 @@ class TestToyMinlipSurvivalAnalysis:
         assert 7 == len(m.timings_)
 
     @staticmethod
-    @pytest.mark.parametrize("solver", ["osqp", "ecos"])
+    @pytest.mark.parametrize("solver", ["osqp", "clarabel", "ecos"])
     def test_predict_1(minlip_model_factory, toy_data, solver):
         x, y = toy_data
         p = minlip_model_factory(solver, x, y).predict(x)
         assert_cindex_almost_equal(y["status"], y["time"], p, (1.0, 11, 0, 0, 0))
 
     @staticmethod
-    @pytest.mark.parametrize("solver", ["osqp", "ecos"])
+    @pytest.mark.parametrize("solver", ["osqp", "clarabel", "ecos"])
     def test_predict_2(minlip_model_factory, toy_data_standardized, solver):
         (x, y), x_test = toy_data_standardized
 
@@ -312,12 +325,15 @@ def svm_model_factory():
     def create_and_fit_model(solver, x, y, **kwargs):
         params = {"solver": solver, "alpha": 2}
         params.update(kwargs)
-        return HingeLossSurvivalSVM(**params).fit(x, y)
+
+        with _get_solver_context(solver):
+            est = HingeLossSurvivalSVM(**params).fit(x, y)
+        return est
 
     return create_and_fit_model
 
 
-@pytest.mark.parametrize("solver", ["osqp", "ecos"])
+@pytest.mark.parametrize("solver", ["osqp", "clarabel", "ecos"])
 @pytest.mark.parametrize("pairs", ["all", "nearest"])
 def test_toy_hinge_fit_and_predict(svm_model_factory, toy_data_standardized, solver, pairs):
     (x, y), x_test = toy_data_standardized
@@ -345,7 +361,7 @@ def gbsg2_scaled(gbsg2):
 
 class TestMinlipBreastCancer:
     @staticmethod
-    @pytest.mark.parametrize("solver,expected_iters", [("osqp", 900), ("ecos", 10)])
+    @pytest.mark.parametrize("solver,expected_iters", [("osqp", 900), ("clarabel", 9), ("ecos", 10)])
     def test_fit_and_predict(gbsg2_scaled, minlip_model_factory, solver, expected_iters):
         x, y = gbsg2_scaled
         m = minlip_model_factory(solver, x, y)
@@ -363,13 +379,13 @@ class TestMinlipBreastCancer:
         "solver,expected_cindex",
         [
             ("osqp", (0.6106092942166647, 81255, 51817, 0, 42)),
+            ("clarabel", (0.6106205663099675, 81256, 51815, 1, 42)),
             ("ecos", (0.6105867500300589, 81252, 51820, 0, 42)),
         ],
     )
     def test_fit_and_predict_rbf(gbsg2_scaled, minlip_model_factory, solver, expected_cindex):
         x, y = gbsg2_scaled
         m = minlip_model_factory(solver, x, y, kernel="rbf", gamma=1.0 / 8, pairs="next", max_iter=1000)
-        m.fit(x, y)
 
         assert (1, x.shape[0]) == m.coef_.shape
 
@@ -378,7 +394,7 @@ class TestMinlipBreastCancer:
 
     @staticmethod
     @pytest.mark.slow()
-    @pytest.mark.parametrize("solver", ["osqp", "ecos"])
+    @pytest.mark.parametrize("solver", ["osqp", "clarabel", "ecos"])
     def test_kernel_precomputed(gbsg2_scaled, solver):
         x, y = gbsg2_scaled
         from sklearn.metrics.pairwise import pairwise_kernels
@@ -392,7 +408,8 @@ class TestMinlipBreastCancer:
         X_fit, y_fit = _safe_split(m, K, y, train_idx)
         X_test, y_test = _safe_split(m, K, y, test_idx, train_idx)
 
-        m.fit(X_fit, y_fit)
+        with _get_solver_context(solver):
+            m.fit(X_fit, y_fit)
 
         p = m.predict(X_test)
         assert_cindex_almost_equal(y_test["cens"], y_test["time"], p, (0.6518928901200369, 8472, 4524, 0, 3))
@@ -405,7 +422,7 @@ class TestMinlipBreastCancer:
         trans = ClinicalKernelTransform()
         trans.fit(whas500.x_data_frame)
 
-        m = MinlipSurvivalAnalysis(kernel=trans.pairwise_kernel)
+        m = MinlipSurvivalAnalysis(solver="clarabel", kernel=trans.pairwise_kernel)
         m.fit(whas500.x, whas500.y)
 
         assert not m.__sklearn_tags__().input_tags.pairwise
@@ -414,13 +431,14 @@ class TestMinlipBreastCancer:
         assert c == pytest.approx(0.7314135916645598)
 
     @staticmethod
-    @pytest.mark.parametrize("solver", ["osqp", "ecos"])
+    @pytest.mark.parametrize("solver", ["OSQP", "clarabel", "ECOS"])
     def test_max_iter(gbsg2_scaled, solver):
         x, y = gbsg2_scaled
-        m = MinlipSurvivalAnalysis(solver=solver, alpha=1, kernel="poly", degree=2, pairs="next", max_iter=5)
+        m = MinlipSurvivalAnalysis(solver=solver.lower(), alpha=1, kernel="poly", degree=2, pairs="next", max_iter=5)
 
-        with pytest.warns(
-            ConvergenceWarning, match=f"{solver.upper()} solver did not converge: maximum iterations reached"
+        with (
+            pytest.warns(ConvergenceWarning, match=f"{solver} solver did not converge: maximum iterations reached"),
+            _get_solver_context(solver.lower()),
         ):
             m.fit(x, y)
 
@@ -443,7 +461,7 @@ def test_unknown_solver(gbsg2, solver):
 
 
 @pytest.mark.parametrize("model_cls", [MinlipSurvivalAnalysis, HingeLossSurvivalSVM])
-@pytest.mark.parametrize("solver", ["ecos", "osqp"])
+@pytest.mark.parametrize("solver", ["ecos", "clarabel", "osqp"])
 @pytest.mark.parametrize("pairs", ["all", "nearest", "next"])
 def test_fit_uncomparable(whas500_uncomparable, model_cls, solver, pairs):
     ssvm = model_cls(solver=solver, pairs=pairs)

--- a/tests/test_pandas_inputs.py
+++ b/tests/test_pandas_inputs.py
@@ -6,6 +6,7 @@ from sksurv.datasets import load_whas500
 from sksurv.testing import all_survival_estimators
 
 
+@pytest.mark.filterwarnings("ignore:The 'ecos' solver will be removed in a future release.:FutureWarning")
 @pytest.mark.parametrize("estimator_cls", all_survival_estimators())
 def test_pandas_inputs(estimator_cls):
     X, y = load_whas500()

--- a/tests/test_polars_estimators.py
+++ b/tests/test_polars_estimators.py
@@ -73,7 +73,7 @@ def _make_survival_estimator_constructors():
                 case "FastSurvivalSVM" | "FastKernelSurvivalSVM":
                     estimator.set_params(max_iter=100, tol=1e-6)
                 case "MinlipSurvivalAnalysis" | "HingeLossSurvivalSVM":
-                    estimator.set_params(solver="ecos")
+                    estimator.set_params(solver="clarabel")
 
             return estimator
 


### PR DESCRIPTION
Can replace ecos, which doesn't seem to be maintained anymore

<!--
♥ Thanks for contributing a pull request! ♥

Please ensure you have taken a look at the contribution guidelines:
https://scikit-survival.readthedocs.io/en/latest/contributing.html#making-changes-to-the-code
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] pytest passes
- [x] tests are included
- [x] code is well formatted
- [x] documentation renders correctly

#### What does this implement/fix? Explain your changes
ECOS has been the default solver for `MinlipSurvivalAnalysis` and `HingeLossSurvivalSVM`. However, ECOS has been unmaintained for a while (only provides wheels up to Python 3.12). [Clarabel](https://github.com/oxfordcontrol/Clarabel.rs) is an alternative Interior-point solver written in Rust with Python bindings.

This PR adds the `sover='clarabel'` option and raises a warning when `solver='ecos'` is being used.

_Note_: cvxpy switched from ECOS to Clarabel too: https://www.cvxpy.org/updates/index.html#ecos-deprecation

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Read our guidelines on using AI tools at
https://scikit-survival.readthedocs.io/en/latest/ai_policy.html
-->
No AI tools were used.